### PR TITLE
Add Raspberry Pi 4 database setup helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,22 +38,20 @@ mkdir build && cd build
 cmake ..
 cmake --build .
 🗄️ Database Setup
-Create a new MariaDB schema + user for swgchat.
 
-Run the initialization script:
+Create a new MariaDB schema + user for swgchat, then run the initialization
+script:
 
-bash
-Copy code
+```bash
 mysql -u <user> -p < extras/init_database.sql
-Edit stationchat.cfg with your DB credentials:
+```
 
-database_host
+Edit `stationchat.cfg` with your DB credentials:
 
-database_user
-
-database_password
-
-database_schema
+- `database_host`
+- `database_user`
+- `database_password`
+- `database_schema`
 
 🌐 Website Integration (Optional)
 swg+ can mirror game data into a website for community portals or account dashboards.
@@ -113,6 +111,23 @@ sudo apt install build-essential cmake libboost-program-options-dev \
 ARM targets, which resolves missing symbol errors that can appear on the Pi 4.
 After installing dependencies the standard Linux build instructions shown above
 apply unchanged.
+
+#### Pi 4 Database Setup
+
+To provision MariaDB on Raspberry Pi OS and import the default schema, run:
+
+```bash
+sudo extras/setup_pi4_database.sh
+```
+
+The helper script will:
+
+1. Install `mariadb-server` if it is missing.
+2. Start and enable the MariaDB service.
+3. Create the `stationchat` schema (if needed).
+4. Prompt you for an admin user + password to import `extras/init_database.sql`.
+
+You can re-run the script safely; it will skip steps that are already complete.
 🔒 Pro tip: Copy build/bin to a safe location before production use. Re-building will overwrite config defaults.
 
 ❤️ Support Development

--- a/extras/setup_pi4_database.sh
+++ b/extras/setup_pi4_database.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure we are running as root (sudo).
+if [[ $(id -u) -ne 0 ]]; then
+    echo "This script must be run with sudo or as root." >&2
+    exit 1
+fi
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+INIT_SQL="${SCRIPT_DIR}/init_database.sql"
+
+if [[ ! -f "${INIT_SQL}" ]]; then
+    echo "Initialization SQL not found at ${INIT_SQL}." >&2
+    exit 1
+fi
+
+# Install MariaDB server if it is not already present.
+if ! dpkg -s mariadb-server >/dev/null 2>&1; then
+    echo "Installing MariaDB server..."
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y mariadb-server
+fi
+
+# Ensure the service is running and enabled on boot.
+if systemctl list-unit-files | grep -q '^mariadb\.service'; then
+    systemctl enable mariadb
+    systemctl start mariadb
+else
+    systemctl enable mysql
+    systemctl start mysql
+fi
+
+# Prompt for credentials used to import the schema.
+read -rp "MariaDB administrative user [root]: " DB_USER
+DB_USER=${DB_USER:-root}
+
+# The root account on Raspberry Pi OS uses the unix_socket plugin by default,
+# so we avoid prompting for a password when the user is root.
+if [[ "${DB_USER}" == "root" ]]; then
+    DB_PASS=""
+else
+    read -rsp "Password for ${DB_USER}: " DB_PASS
+    echo
+fi
+
+CREATE_DB_SQL=$'CREATE DATABASE IF NOT EXISTS stationchat\n  CHARACTER SET utf8mb4\n  COLLATE utf8mb4_unicode_ci;'
+
+if [[ -z "${DB_PASS}" ]]; then
+    echo "Ensuring stationchat database exists..."
+    mysql -u "${DB_USER}" -e "${CREATE_DB_SQL}"
+    echo "Importing schema from ${INIT_SQL}..."
+    mysql -u "${DB_USER}" stationchat < "${INIT_SQL}"
+else
+    echo "Ensuring stationchat database exists..."
+    mysql -u "${DB_USER}" -p"${DB_PASS}" -e "${CREATE_DB_SQL}"
+    echo "Importing schema from ${INIT_SQL}..."
+    mysql -u "${DB_USER}" -p"${DB_PASS}" stationchat < "${INIT_SQL}"
+fi
+
+echo "Database setup complete. Update stationchat.cfg with your connection details."


### PR DESCRIPTION
## Summary
- improve the database setup instructions in the README, including Pi 4 specifics
- add a Raspberry Pi 4 helper script that installs MariaDB and imports the default schema

## Testing
- not run (documentation and setup script changes only)


------
https://chatgpt.com/codex/tasks/task_e_68dd91371f6c832ca3d1ae1b969f8829