### PR TITLE
Add gateway clustering support with load-balanced registrar

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,24 @@ List all characters for a user
 
 Render mailboxes in sync with the game
 
+### ♻️ Clustering & Load Distribution
+
+Need to scale beyond a single gateway? Add multiple `gateway_cluster` entries to
+your configuration (either on the command line or inside `stationchat.cfg`).
+Each entry is expressed as `host:port[:weight]` and the local gateway is added
+automatically, so you only need to list additional nodes.
+
+```ini
+# Send twice as many users to 192.168.1.12 as the other nodes
+gateway_cluster = 192.168.1.10:5001
+gateway_cluster = 192.168.1.11:5001
+gateway_cluster = 192.168.1.12:5001:2
+```
+
+The registrar answers new login requests by walking the cluster list in a
+weighted round-robin pattern, allowing you to spread connections across
+multiple machines while keeping all nodes in sync through the shared database.
+
 🚀 Running
 Windows
 

--- a/src/stationchat/RegistrarNode.cpp
+++ b/src/stationchat/RegistrarNode.cpp
@@ -3,9 +3,13 @@
 
 #include "StationChatConfig.hpp"
 
+#include <algorithm>
+
 RegistrarNode::RegistrarNode(StationChatConfig& config)
     : Node(this, config.registrarAddress, config.registrarPort, config.bindToIp)
-    , config_{config} {}
+    , config_{config} {
+    RebuildClusterView();
+}
 
 RegistrarNode::~RegistrarNode() {}
 
@@ -13,5 +17,44 @@ StationChatConfig& RegistrarNode::GetConfig() {
     return config_;
 }
 
+GatewayClusterEndpoint RegistrarNode::SelectGatewayEndpoint() {
+    if (weightedGatewayEndpoints_.empty()) {
+        return {config_.gatewayAddress, config_.gatewayPort, 1};
+    }
+
+    auto index = nextGatewayIndex_.fetch_add(1, std::memory_order_relaxed);
+    const auto& endpoint = weightedGatewayEndpoints_[index % weightedGatewayEndpoints_.size()];
+    return endpoint;
+}
+
 void RegistrarNode::OnTick() {}
+
+void RegistrarNode::RebuildClusterView() {
+    // Clamp weights to avoid exploding the weighted view if an extremely large
+    // value is configured. The registrar still honors relative weights while
+    // keeping the in-memory representation bounded.
+    static constexpr uint16_t kMaxWeight = 100;
+
+    weightedGatewayEndpoints_.clear();
+
+    const auto appendEndpoint = [this](const GatewayClusterEndpoint& endpoint) {
+        weightedGatewayEndpoints_.push_back(endpoint);
+    };
+
+    if (!config_.gatewayCluster.empty()) {
+        for (const auto& endpoint : config_.gatewayCluster) {
+            const auto weight = std::max<uint16_t>(static_cast<uint16_t>(1), endpoint.weight);
+            const auto repetitions = std::min<uint16_t>(weight, kMaxWeight);
+            for (uint16_t repeat = 0; repeat < repetitions; ++repeat) {
+                appendEndpoint(endpoint);
+            }
+        }
+    }
+
+    if (weightedGatewayEndpoints_.empty()) {
+        appendEndpoint({config_.gatewayAddress, config_.gatewayPort, 1});
+    }
+
+    nextGatewayIndex_.store(0, std::memory_order_relaxed);
+}
 

--- a/src/stationchat/RegistrarNode.hpp
+++ b/src/stationchat/RegistrarNode.hpp
@@ -3,8 +3,10 @@
 
 #include "Node.hpp"
 #include "RegistrarClient.hpp"
+#include "StationChatConfig.hpp"
 
-struct StationChatConfig;
+#include <atomic>
+#include <vector>
 
 class RegistrarNode : public Node<RegistrarNode, RegistrarClient> {
 public:
@@ -12,9 +14,13 @@ public:
     ~RegistrarNode();
 
     StationChatConfig& GetConfig();
+    GatewayClusterEndpoint SelectGatewayEndpoint();
 
 private:
     void OnTick() override;
+    void RebuildClusterView();
 
     StationChatConfig& config_;
+    std::vector<GatewayClusterEndpoint> weightedGatewayEndpoints_;
+    std::atomic<size_t> nextGatewayIndex_{0};
 };

--- a/src/stationchat/StationChatApp.cpp
+++ b/src/stationchat/StationChatApp.cpp
@@ -4,6 +4,8 @@
 
 StationChatApp::StationChatApp(StationChatConfig config)
     : config_{std::move(config)} {
+    config_.NormalizeClusterGateways();
+
     registrarNode_ = std::make_unique<RegistrarNode>(config_);
     LOG(INFO) << "Registrar listening @" << config_.registrarAddress << ":" << config_.registrarPort;
 

--- a/src/stationchat/protocol/Protocol.cpp
+++ b/src/stationchat/protocol/Protocol.cpp
@@ -492,10 +492,10 @@ LogoutAvatar::LogoutAvatar(GatewayClient* client, const RequestType& request, Re
 }
 
 RegistrarGetChatServer::RegistrarGetChatServer(RegistrarClient* client, const RequestType& request, ResponseType& response) {
-    auto& config = client->GetNode()->GetConfig();
+    auto endpoint = client->GetNode()->SelectGatewayEndpoint();
 
-    response.hostname = ToWideString(config.gatewayAddress);
-    response.port = config.gatewayPort;
+    response.hostname = ToWideString(endpoint.address);
+    response.port = endpoint.port;
 }
 
 RemoveBan::RemoveBan(GatewayClient* client, const RequestType& request, ResponseType& response)


### PR DESCRIPTION
## Summary
- add a structured gateway cluster configuration that normalizes membership and weights
- teach the registrar to serve gateway addresses via a weighted round-robin selector
- parse the new gateway_cluster option and document clustering in the README

## Testing
- cmake -S . -B build *(fails: udplibrary required... copy from swg source to the externals directory)*

------
https://chatgpt.com/codex/tasks/task_e_68dd92a17448832cbaed8dfd42934b36