### PR TITLE
Add Raspberry Pi build guide and Ant wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 externals/udplibrary
-build*
+build*/
 .vscode/

--- a/README.md
+++ b/README.md
@@ -23,20 +23,62 @@
 
 - C++14-compatible compiler  
 - [Boost.Program_options](https://www.boost.org/doc/libs/release/doc/html/program_options.html)  
-- [MariaDB Client Libraries](https://mariadb.com/kb/en/mariadb-client-library/)  
-- `udplibrary` (from the original SWG source; must be copied in)  
+- [MariaDB Client Libraries](https://mariadb.com/kb/en/mariadb-client-library/)
+- `udplibrary` (from the original SWG source; must be copied in)
+- [Apache Ant](https://ant.apache.org/) (optional, for the legacy-compatible build wrapper)
 
 ---
 
-## ⚙️ Build Instructions  
+## ⚙️ Build Instructions
 
-Clone the repository and ensure `udplibrary/` is present in the project root.  
-Install dependencies via your package manager, then build:
+The steps below show a complete Raspberry Pi workflow from the shell prompt the
+legacy guides referenced:
+
+```
+swg@raspberrypi:~ $ sudo apt update
+swg@raspberrypi:~ $ sudo apt install git ant build-essential cmake \
+    libboost-program-options-dev libmariadb-dev libmariadb-dev-compat libatomic1
+swg@raspberrypi:~ $ git clone https://github.com/YOURNAME/swgplus.git stationapi
+swg@raspberrypi:~ $ cd stationapi
+swg@raspberrypi:~/stationapi $ cp -r /path/to/original/udplibrary ./udplibrary
+```
+
+Once the prerequisites are in place you can build with either CMake directly or
+via the Ant compatibility target described in the next section.
+
+### Option A – CMake (native build system)
 
 ```bash
-mkdir build && cd build
-cmake ..
-cmake --build .
+swg@raspberrypi:~/stationapi $ cmake -S . -B build
+swg@raspberrypi:~/stationapi $ cmake --build build
+```
+
+> 💡 Prefer the `-S`/`-B` syntax shown above instead of running `cmake ..` from
+> inside the `build` directory. It makes the intended source and binary
+> directories explicit and avoids the common
+> `CMake Error: The source directory "/home/swg" does not appear to contain
+> CMakeLists.txt` message that appears when CMake is pointed at the wrong path.
+
+### Option B – `ant compile_chat` (legacy-compatible wrapper)
+
+For anyone migrating from the original SWG Station build scripts, the repo ships
+with a small Ant wrapper that mirrors the historical `ant compile_chat`
+workflow:
+
+```bash
+swg@raspberrypi:~/stationapi $ ant compile_chat
+```
+
+Under the hood this target simply calls the same `cmake -S . -B build` and
+`cmake --build build` commands shown above, but it preserves the familiar
+command name for older deployment guides.
+
+To remove build artifacts created by either approach, run:
+
+```bash
+swg@raspberrypi:~/stationapi $ ant clean
+```
+
 🗄️ Database Setup
 
 Create a new MariaDB schema + user for swgchat, then run the initialization

--- a/README.md
+++ b/README.md
@@ -93,6 +93,43 @@ If the helper could create the `/chat` symlink you can start the service with
 `cd /chat && ./stationchat`; otherwise run from `/home/swg/chat` or create your
 own link.
 
+### Keeping `stationchat` alive across reboots
+
+Once the binaries are staged, you can hand service management over to systemd so
+the chat gateway automatically restarts on failures and after power cycles.
+Install [tmux](https://github.com/tmux/tmux/wiki) (used to provide a detachable
+terminal) and drop in the packaged unit:
+
+```bash
+swg@raspberrypi:~/stationapi $ sudo apt install tmux
+swg@raspberrypi:~/stationapi $ sudo ./extras/install_stationchat_service.sh
+swg@raspberrypi:~/stationapi $ sudo systemctl enable --now stationchat.service
+```
+
+The installer copies a small wrapper to `/usr/local/bin/stationchat-tmux-wrapper`
+and writes `/etc/systemd/system/stationchat.service`. The unit launches
+`stationchat` inside a named `tmux` session (`stationchat` by default) so you can
+reattach to the live console at any time:
+
+```bash
+swg@raspberrypi:~ $ sudo -u swg tmux attach -t stationchat
+```
+
+Detach with <kbd>Ctrl</kbd>+<kbd>B</kbd> followed by <kbd>D</kbd> to leave the
+service running in the background. Systemd is configured to restart the gateway
+five seconds after any unexpected exit. To stop or disable the service use:
+
+```bash
+swg@raspberrypi:~ $ sudo systemctl stop stationchat.service
+swg@raspberrypi:~ $ sudo systemctl disable stationchat.service
+```
+
+Customise the install by exporting environment variables before running the
+installer, e.g. set `STATIONAPI_CHAT_SERVICE_USER` when your runtime user differs
+from `swg`, `STATIONAPI_CHAT_PREFIX` when the chat files live outside
+`/home/swg/chat`, or `STATIONAPI_CHAT_TMUX_SESSION` if you want a different tmux
+session name.
+
 ### Option B – `ant compile_chat` (legacy-compatible wrapper)
 
 For anyone migrating from the original SWG Station build scripts, the repo ships

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ swg@raspberrypi:~/stationapi $ ./extras/bootstrap_build.sh
 The helper clones `udplibrary` (skipping the step if it already exists), builds
 the project, and installs the runtime plus default configuration files into
 `/home/swg/chat`. It also drops a `stationchat` launcher alongside the `bin/`
-folder and attempts to link `/chat` back to that install directory so you can
-start the server with:
+folder, backfills any missing default configs, and attempts to link `/chat`
+back to that install directory so you can start the server with:
 
 ```bash
 swg@raspberrypi:~ $ cd /chat
@@ -86,9 +86,12 @@ swg@raspberrypi:~/stationapi $ ./extras/finalize_chat_install.sh /home/swg/chat
 
 This sequence leaves a ready-to-run layout in `/home/swg/chat` with the
 `stationchat` launcher in the top-level directory, the executable itself under
-`bin/`, and configuration files under `etc/stationapi/`. If the helper could
-create the `/chat` symlink you can start the service with `cd /chat &&
-./stationchat`; otherwise run from `/home/swg/chat` or create your own link.
+`bin/`, and configuration files under `etc/stationapi/`. The launcher now
+automatically switches to the install directory before starting the binary so
+relative config paths resolve correctly even if you run it from somewhere else.
+If the helper could create the `/chat` symlink you can start the service with
+`cd /chat && ./stationchat`; otherwise run from `/home/swg/chat` or create your
+own link.
 
 ### Option B – `ant compile_chat` (legacy-compatible wrapper)
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ swg@raspberrypi:~ $ sudo apt install git ant build-essential cmake \
     libboost-program-options-dev libmariadb-dev libmariadb-dev-compat libatomic1
 swg@raspberrypi:~ $ git clone https://github.com/YOURNAME/swgplus.git stationapi
 swg@raspberrypi:~ $ cd stationapi
-swg@raspberrypi:~/stationapi $ cp -r /path/to/original/udplibrary ./udplibrary
+swg@raspberrypi:~/stationapi $ cp -r /path/to/original/udplibrary ./externals/
+# (Result: ./externals/udplibrary/...)
 ```
 
 Once the prerequisites are in place you can build with either CMake directly or
@@ -71,7 +72,10 @@ swg@raspberrypi:~/stationapi $ ant compile_chat
 
 Under the hood this target simply calls the same `cmake -S . -B build` and
 `cmake --build build` commands shown above, but it preserves the familiar
-command name for older deployment guides.
+command name for older deployment guides. The wrapper performs a quick check
+before invoking CMake and stops early with a clear error if
+`externals/udplibrary` is missing so you know to copy the proprietary library
+over before retrying.
 
 To remove build artifacts created by either approach, run:
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ swg@raspberrypi:~ $ git clone https://github.com/YOURNAME/swgplus.git stationapi
 swg@raspberrypi:~ $ cd stationapi
 swg@raspberrypi:~/stationapi $ cp -r /path/to/original/udplibrary ./externals/
 # (Result: ./externals/udplibrary/...)
+
+# Or let the helper script pull and build everything in one go:
+swg@raspberrypi:~/stationapi $ ./extras/bootstrap_build.sh
 ```
 
 Once the prerequisites are in place you can build with either CMake directly or

--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ swg@raspberrypi:~/stationapi $ cp -r /path/to/original/udplibrary ./externals/
 
 # Or let the helper script pull and build everything in one go:
 swg@raspberrypi:~/stationapi $ ./extras/bootstrap_build.sh
+
+The helper clones `udplibrary` (skipping the step if it already exists), builds
+the project, and installs the runtime plus default configuration files into
+`/home/swg/chat`. Set the `STATIONAPI_CHAT_PREFIX` environment variable if you
+want the install to land somewhere else, e.g.
+
+```
+swg@raspberrypi:~/stationapi $ STATIONAPI_CHAT_PREFIX=$HOME/test-chat ./extras/bootstrap_build.sh
+```
 ```
 
 Once the prerequisites are in place you can build with either CMake directly or
@@ -55,6 +64,7 @@ via the Ant compatibility target described in the next section.
 ```bash
 swg@raspberrypi:~/stationapi $ cmake -S . -B build
 swg@raspberrypi:~/stationapi $ cmake --build build
+swg@raspberrypi:~/stationapi $ cmake --install build --prefix /home/swg/chat
 ```
 
 > 💡 Prefer the `-S`/`-B` syntax shown above instead of running `cmake ..` from
@@ -62,6 +72,10 @@ swg@raspberrypi:~/stationapi $ cmake --build build
 > directories explicit and avoids the common
 > `CMake Error: The source directory "/home/swg" does not appear to contain
 > CMakeLists.txt` message that appears when CMake is pointed at the wrong path.
+
+This sequence leaves a ready-to-run layout in `/home/swg/chat` with the
+`stationchat` executable under `bin/` and configuration files under
+`etc/stationapi/`.
 
 ### Option B – `ant compile_chat` (legacy-compatible wrapper)
 
@@ -74,11 +88,13 @@ swg@raspberrypi:~/stationapi $ ant compile_chat
 ```
 
 Under the hood this target simply calls the same `cmake -S . -B build` and
-`cmake --build build` commands shown above, but it preserves the familiar
+`cmake --build build` commands shown above followed by
+`cmake --install build --prefix /home/swg/chat`, but it preserves the familiar
 command name for older deployment guides. The wrapper performs a quick check
 before invoking CMake and stops early with a clear error if
 `externals/udplibrary` is missing so you know to copy the proprietary library
-over before retrying.
+over before retrying. Pass `-Dinstall.prefix=/path/to/chatdir` if you need a
+different install location.
 
 To remove build artifacts created by either approach, run:
 

--- a/build.xml
+++ b/build.xml
@@ -5,6 +5,7 @@
     </description>
 
     <property name="build.dir" value="build"/>
+    <property name="install.prefix" value="/home/swg/chat"/>
 
     <condition property="udplibrary.present">
         <available file="externals/udplibrary/CMakeLists.txt"/>
@@ -32,6 +33,12 @@
         <exec executable="cmake" failonerror="true">
             <arg value="--build"/>
             <arg value="${build.dir}"/>
+        </exec>
+        <exec executable="cmake" failonerror="true">
+            <arg value="--install"/>
+            <arg value="${build.dir}"/>
+            <arg value="--prefix"/>
+            <arg value="${install.prefix}"/>
         </exec>
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -6,6 +6,7 @@
 
     <property name="build.dir" value="build"/>
     <property name="install.prefix" value="/home/swg/chat"/>
+    <property name="run.link" value="/chat"/>
 
     <condition property="udplibrary.present">
         <available file="externals/udplibrary/CMakeLists.txt"/>
@@ -39,6 +40,10 @@
             <arg value="${build.dir}"/>
             <arg value="--prefix"/>
             <arg value="${install.prefix}"/>
+        </exec>
+        <exec executable="${basedir}/extras/finalize_chat_install.sh" failonerror="true">
+            <arg value="${install.prefix}"/>
+            <arg value="${run.link}"/>
         </exec>
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="stationchat" default="compile_chat" basedir=".">
+    <description>
+        Ant compatibility wrapper that configures and builds the CMake project.
+    </description>
+
+    <property name="build.dir" value="build"/>
+
+    <target name="configure">
+        <mkdir dir="${build.dir}"/>
+        <exec executable="cmake" failonerror="true">
+            <arg value="-S"/>
+            <arg value="."/>
+            <arg value="-B"/>
+            <arg value="${build.dir}"/>
+        </exec>
+    </target>
+
+    <target name="compile_chat" depends="configure">
+        <exec executable="cmake" failonerror="true">
+            <arg value="--build"/>
+            <arg value="${build.dir}"/>
+        </exec>
+    </target>
+
+    <target name="clean">
+        <delete dir="${build.dir}"/>
+    </target>
+</project>

--- a/build.xml
+++ b/build.xml
@@ -6,7 +6,19 @@
 
     <property name="build.dir" value="build"/>
 
-    <target name="configure">
+    <condition property="udplibrary.present">
+        <available file="externals/udplibrary/CMakeLists.txt"/>
+    </condition>
+
+    <target name="require-udplibrary">
+        <fail unless="udplibrary.present">
+            Missing externals/udplibrary. Copy the proprietary udplibrary from the
+            original SWG source into externals/udplibrary before running this
+            target.
+        </fail>
+    </target>
+
+    <target name="configure" depends="require-udplibrary">
         <mkdir dir="${build.dir}"/>
         <exec executable="cmake" failonerror="true">
             <arg value="-S"/>

--- a/extras/bootstrap_build.sh
+++ b/extras/bootstrap_build.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 UDP_DIR="${REPO_ROOT}/externals/udplibrary"
+INSTALL_PREFIX_DEFAULT="/home/swg/chat"
+INSTALL_PREFIX="${STATIONAPI_CHAT_PREFIX:-${INSTALL_PREFIX_DEFAULT}}"
 
 if [[ ! -d "${UDP_DIR}" ]]; then
   echo "Cloning udplibrary into externals/udplibrary..."
@@ -16,5 +18,8 @@ mkdir -p "${BUILD_DIR}"
 
 pushd "${BUILD_DIR}" >/dev/null
 cmake ..
-make
+cmake --build .
+cmake --install . --prefix "${INSTALL_PREFIX}"
 popd >/dev/null
+
+echo "Installed chat runtime to ${INSTALL_PREFIX}"

--- a/extras/bootstrap_build.sh
+++ b/extras/bootstrap_build.sh
@@ -5,6 +5,8 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 UDP_DIR="${REPO_ROOT}/externals/udplibrary"
 INSTALL_PREFIX_DEFAULT="/home/swg/chat"
 INSTALL_PREFIX="${STATIONAPI_CHAT_PREFIX:-${INSTALL_PREFIX_DEFAULT}}"
+RUN_LINK_DEFAULT="/chat"
+RUN_LINK="${STATIONAPI_CHAT_RUNLINK:-${RUN_LINK_DEFAULT}}"
 
 if [[ ! -d "${UDP_DIR}" ]]; then
   echo "Cloning udplibrary into externals/udplibrary..."
@@ -22,4 +24,4 @@ cmake --build .
 cmake --install . --prefix "${INSTALL_PREFIX}"
 popd >/dev/null
 
-echo "Installed chat runtime to ${INSTALL_PREFIX}"
+"${REPO_ROOT}/extras/finalize_chat_install.sh" "${INSTALL_PREFIX}" "${RUN_LINK}"

--- a/extras/bootstrap_build.sh
+++ b/extras/bootstrap_build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+UDP_DIR="${REPO_ROOT}/externals/udplibrary"
+
+if [[ ! -d "${UDP_DIR}" ]]; then
+  echo "Cloning udplibrary into externals/udplibrary..."
+  git clone https://bitbucket.org/swgathrawn/udplibrary.git "${UDP_DIR}"
+else
+  echo "udplibrary already present at externals/udplibrary; skipping clone."
+fi
+
+BUILD_DIR="${REPO_ROOT}/build"
+mkdir -p "${BUILD_DIR}"
+
+pushd "${BUILD_DIR}" >/dev/null
+cmake ..
+make
+popd >/dev/null

--- a/extras/finalize_chat_install.sh
+++ b/extras/finalize_chat_install.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INSTALL_PREFIX="${1:?Provide an install prefix}"
+RUN_LINK="${2:-/chat}"
+
+STATIONCHAT_BIN="${INSTALL_PREFIX}/bin/stationchat"
+if [[ ! -x "${STATIONCHAT_BIN}" ]]; then
+  echo "Error: ${STATIONCHAT_BIN} not found or not executable. Ensure cmake --install completed successfully." >&2
+  exit 1
+fi
+
+WRAPPER_PATH="${INSTALL_PREFIX}/stationchat"
+cat <<'WRAP' >"${WRAPPER_PATH}"
+#!/usr/bin/env bash
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${DIR}/bin/stationchat" "$@"
+WRAP
+chmod +x "${WRAPPER_PATH}"
+
+RUN_LOCATION="${INSTALL_PREFIX}"
+if [[ -n "${RUN_LINK}" ]]; then
+  if [[ -e "${RUN_LINK}" && ! -L "${RUN_LINK}" ]]; then
+    echo "Warning: ${RUN_LINK} exists and is not a symlink; skipping creation of chat run link." >&2
+  else
+    if ln -sfn "${INSTALL_PREFIX}" "${RUN_LINK}"; then
+      RUN_LOCATION="${RUN_LINK}"
+      echo "Linked ${RUN_LINK} -> ${INSTALL_PREFIX}"
+    else
+      echo "Warning: unable to create ${RUN_LINK} -> ${INSTALL_PREFIX}. Create the link manually if desired." >&2
+    fi
+  fi
+fi
+
+echo "Launcher installed to ${WRAPPER_PATH}"  
+echo "Start the chat server with:"  
+echo "  cd ${RUN_LOCATION}"  
+echo "  ./stationchat"

--- a/extras/finalize_chat_install.sh
+++ b/extras/finalize_chat_install.sh
@@ -10,12 +10,31 @@ if [[ ! -x "${STATIONCHAT_BIN}" ]]; then
   exit 1
 fi
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+CONFIG_SOURCE_DIR="${SCRIPT_DIR}"
+CONFIG_TARGET_DIR="${INSTALL_PREFIX}/etc/stationapi"
+mkdir -p "${CONFIG_TARGET_DIR}"
+for cfg in swgchat logger; do
+  TARGET_PATH="${CONFIG_TARGET_DIR}/${cfg}.cfg"
+  if [[ ! -f "${TARGET_PATH}" ]]; then
+    DIST_PATH="${CONFIG_SOURCE_DIR}/${cfg}.cfg.dist"
+    if [[ -f "${DIST_PATH}" ]]; then
+      cp "${DIST_PATH}" "${TARGET_PATH}"
+      echo "Copied default ${cfg}.cfg to ${TARGET_PATH}"
+    else
+      echo "Warning: missing ${TARGET_PATH} and unable to locate ${DIST_PATH}." >&2
+    fi
+  fi
+done
+
 WRAPPER_PATH="${INSTALL_PREFIX}/stationchat"
 cat <<'WRAP' >"${WRAPPER_PATH}"
 #!/usr/bin/env bash
 set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec "${DIR}/bin/stationchat" "$@"
+cd "${DIR}"
+exec "./bin/stationchat" "$@"
 WRAP
 chmod +x "${WRAPPER_PATH}"
 

--- a/extras/install_stationchat_service.sh
+++ b/extras/install_stationchat_service.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PREFIX="${STATIONAPI_CHAT_PREFIX:-/home/swg/chat}"
+SERVICE_NAME="${STATIONAPI_CHAT_SERVICE_NAME:-stationchat}"
+SESSION_NAME="${STATIONAPI_CHAT_TMUX_SESSION:-stationchat}"
+RUN_USER="${STATIONAPI_CHAT_SERVICE_USER:-swg}"
+WRAPPER_TARGET="${STATIONAPI_CHAT_WRAPPER_PATH:-/usr/local/bin/stationchat-tmux-wrapper}"
+UNIT_PATH="${STATIONAPI_CHAT_SERVICE_UNIT:-/etc/systemd/system/${SERVICE_NAME}.service}"
+TMUX_BIN="${STATIONAPI_CHAT_TMUX_BIN:-tmux}"
+
+if command -v "$TMUX_BIN" >/dev/null 2>&1; then
+  TMUX_BIN="$(command -v "$TMUX_BIN")"
+fi
+
+if [[ $EUID -ne 0 ]]; then
+  echo "install_stationchat_service.sh must be run as root (try sudo)." >&2
+  exit 1
+fi
+
+if [[ -z "$TMUX_BIN" ]]; then
+  echo "install_stationchat_service.sh: tmux is required. Install it with 'sudo apt install tmux'." >&2
+  exit 1
+fi
+
+if [[ ! -d "$PREFIX" ]]; then
+  echo "install_stationchat_service.sh: install prefix '$PREFIX' does not exist. Build and install the chat gateway first." >&2
+  exit 1
+fi
+
+if [[ ! -x "$PREFIX/stationchat" ]]; then
+  echo "install_stationchat_service.sh: expected '${PREFIX}/stationchat' to exist. Did you run cmake --install or bootstrap_build.sh?" >&2
+  exit 1
+fi
+
+install -Dm755 "$SCRIPT_DIR/stationchat_tmux_wrapper.sh" "$WRAPPER_TARGET"
+
+cat >"$UNIT_PATH" <<EOF_UNIT
+[Unit]
+Description=SWG Station Chat Gateway (tmux-managed console)
+After=network-online.target mariadb.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=$RUN_USER
+WorkingDirectory=$PREFIX
+Environment=STATIONAPI_CHAT_PREFIX=$PREFIX
+Environment=STATIONAPI_CHAT_TMUX_SESSION=$SESSION_NAME
+Environment=STATIONAPI_CHAT_BIN=$PREFIX/stationchat
+Environment=STATIONAPI_CHAT_TMUX_BIN=$TMUX_BIN
+ExecStart=$WRAPPER_TARGET
+ExecStop=/usr/bin/env bash -c '$TMUX_BIN send-keys -t $SESSION_NAME C-c >/dev/null 2>&1 || true'
+ExecStopPost=/usr/bin/env bash -c '$TMUX_BIN kill-session -t $SESSION_NAME >/dev/null 2>&1 || true'
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF_UNIT
+
+chmod 644 "$UNIT_PATH"
+
+systemctl daemon-reload
+
+cat <<EOF_MSG
+Installed $UNIT_PATH
+Wrapper copied to $WRAPPER_TARGET
+
+Enable the service with:
+  systemctl enable --now ${SERVICE_NAME}.service
+
+Attach to the live console with:
+  sudo -u $RUN_USER $TMUX_BIN attach -t $SESSION_NAME
+EOF_MSG

--- a/extras/stationchat_tmux_wrapper.sh
+++ b/extras/stationchat_tmux_wrapper.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SESSION="${STATIONAPI_CHAT_TMUX_SESSION:-stationchat}"
+PREFIX="${STATIONAPI_CHAT_PREFIX:-/home/swg/chat}"
+CHAT_BIN="${STATIONAPI_CHAT_BIN:-${PREFIX}/stationchat}"
+TMUX_BIN="${STATIONAPI_CHAT_TMUX_BIN:-tmux}"
+
+if ! command -v "$TMUX_BIN" >/dev/null 2>&1; then
+  echo "stationchat_tmux_wrapper: tmux is required but was not found in PATH" >&2
+  exit 1
+fi
+
+if [[ ! -x "$CHAT_BIN" ]]; then
+  echo "stationchat_tmux_wrapper: expected runnable stationchat binary at '$CHAT_BIN'" >&2
+  exit 1
+fi
+
+# Create a temporary directory to capture the exit code of the chat process.
+STATE_DIR=$(mktemp -d)
+trap 'rm -rf "$STATE_DIR"' EXIT
+STATUS_FILE="$STATE_DIR/status"
+
+printf -v START_COMMAND 'cd %q && exec %q' "$PREFIX" "$CHAT_BIN"
+
+# If a previous session exists, terminate it before starting a new one.
+if "$TMUX_BIN" has-session -t "$SESSION" 2>/dev/null; then
+  "$TMUX_BIN" send-keys -t "$SESSION" C-c >/dev/null 2>&1 || true
+  sleep 1
+  "$TMUX_BIN" kill-session -t "$SESSION" >/dev/null 2>&1 || true
+fi
+
+"$TMUX_BIN" new-session -d -s "$SESSION" "${START_COMMAND}; EXIT_CODE=\$?; echo \$EXIT_CODE > '$STATUS_FILE';" >/dev/null
+
+# Wait until the session terminates and the exit status is written.
+while "$TMUX_BIN" has-session -t "$SESSION" 2>/dev/null; do
+  sleep 2
+  if [[ -s "$STATUS_FILE" ]]; then
+    break
+  fi
+done
+
+if [[ -s "$STATUS_FILE" ]]; then
+  read -r EXIT_CODE < "$STATUS_FILE"
+else
+  EXIT_CODE=0
+fi
+
+exit "$EXIT_CODE"


### PR DESCRIPTION
## Summary
- document a full Raspberry Pi setup flow starting from the classic `swg@raspberrypi:~/stationapi $` prompt
- add an Apache Ant wrapper so `ant compile_chat` and `ant clean` proxy the CMake build
- tweak `.gitignore` so the new wrapper is tracked while still ignoring generated build directories

## Testing
- not run (requires the proprietary `udplibrary` dependency)


------
https://chatgpt.com/codex/tasks/task_e_68e176492b24832cb2727ae9f7f09351