### PR TITLE
Add chat system classification for spatial, planet, and galaxy channels

### DIFF
--- a/src/stationchat/CMakeLists.txt
+++ b/src/stationchat/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(
   ChatAvatarService.hpp
   ChatEnums.cpp
   ChatEnums.hpp
+  ChatSystem.hpp
   ChatRoom.cpp
   ChatRoom.hpp
   ChatRoomService.cpp

--- a/src/stationchat/ChatEnums.hpp
+++ b/src/stationchat/ChatEnums.hpp
@@ -4,6 +4,40 @@
 #include <cstdint>
 #include <string>
 
+enum class ChatSystemType : uint32_t {
+    SPATIAL = 0,
+    PLANET = 1,
+    GALAXY = 2,
+};
+
+inline ChatSystemType ChatSystemFromNodeLevel(uint32_t nodeLevel) {
+    switch (static_cast<ChatSystemType>(nodeLevel)) {
+    case ChatSystemType::SPATIAL:
+    case ChatSystemType::PLANET:
+    case ChatSystemType::GALAXY:
+        return static_cast<ChatSystemType>(nodeLevel);
+    default:
+        return ChatSystemType::SPATIAL;
+    }
+}
+
+inline uint32_t NodeLevelFromChatSystem(ChatSystemType type) {
+    return static_cast<uint32_t>(type);
+}
+
+inline const char* ToString(ChatSystemType type) {
+    switch (type) {
+    case ChatSystemType::SPATIAL:
+        return "SPATIAL";
+    case ChatSystemType::PLANET:
+        return "PLANET";
+    case ChatSystemType::GALAXY:
+        return "GALAXY";
+    default:
+        return "SPATIAL";
+    }
+}
+
 enum class ChatRequestType : uint16_t {
     LOGINAVATAR = 0,
     LOGOUTAVATAR,

--- a/src/stationchat/ChatRoom.hpp
+++ b/src/stationchat/ChatRoom.hpp
@@ -50,6 +50,8 @@ public:
     uint32_t GetRoomId() const { return roomId_; }
     uint32_t GetCreateTime() const { return createTime_; }
     uint32_t GetNodeLevel() const { return nodeLevel_; }
+    ChatSystemType GetChatSystem() const { return ChatSystemFromNodeLevel(nodeLevel_); }
+    void SetChatSystem(ChatSystemType system) { nodeLevel_ = NodeLevelFromChatSystem(system); }
 
     const std::vector<ChatAvatar*> GetAvatars() const { return avatars_; }    
     /** Returns a list of id's in the room that are not ignoring the srcAvatar.
@@ -104,7 +106,7 @@ private:
     uint32_t maxRoomSize_;
     uint32_t roomId_ = 0;
     uint32_t createTime_ = 0;
-    uint32_t nodeLevel_ = 0;
+    uint32_t nodeLevel_ = NodeLevelFromChatSystem(ChatSystemType::SPATIAL);
     uint32_t roomMessageId_ = 1;
     int32_t dbId_ = -1;
 

--- a/src/stationchat/ChatRoomService.cpp
+++ b/src/stationchat/ChatRoomService.cpp
@@ -1,5 +1,6 @@
 #include "ChatRoomService.hpp"
 #include "ChatAvatarService.hpp"
+#include "ChatSystem.hpp"
 #include "MariaDB.hpp"
 #include "StreamUtils.hpp"
 #include "StringUtils.hpp"
@@ -65,6 +66,8 @@ void ChatRoomService::LoadRoomsFromStorage(const std::u16string& baseAddress) {
         room->createTime_ = mariadb_column_int(stmt, 12);
         room->nodeLevel_ = mariadb_column_int(stmt, 13);
 
+        room->SetChatSystem(DetermineChatSystem(room->GetRoomName(), room->GetRoomAddress()));
+
         if (!RoomExists(room->GetRoomAddress())) {
             rooms_.emplace_back(std::move(room));
         }
@@ -89,6 +92,8 @@ ChatRoom* ChatRoomService::CreateRoom(const ChatAvatar* creator,
     rooms_.emplace_back(std::make_unique<ChatRoom>(this, nextRoomId_++, creator, roomName,
         roomTopic, roomPassword, roomAttributes, maxRoomSize, roomAddress, srcAddress));
     roomPtr = rooms_.back().get();
+
+    roomPtr->SetChatSystem(DetermineChatSystem(roomPtr->GetRoomName(), roomPtr->GetRoomAddress()));
 
     if (roomPtr->IsPersistent()) {
         PersistNewRoom(*roomPtr);

--- a/src/stationchat/ChatSystem.hpp
+++ b/src/stationchat/ChatSystem.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "ChatEnums.hpp"
+#include "StringUtils.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+inline std::string NormalizeChatSystemToken(const std::u16string& value) {
+    auto ascii = FromWideString(value);
+    std::string normalized(ascii.size(), '\0');
+    std::transform(ascii.begin(), ascii.end(), normalized.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    return normalized;
+}
+
+inline bool ContainsChatSystemKeyword(const std::string& haystack, const char* keyword) {
+    return haystack.find(keyword) != std::string::npos;
+}
+
+inline bool DetectChatSystem(const std::string& token, ChatSystemType& detectedType) {
+    if (ContainsChatSystemKeyword(token, "galaxy")) {
+        detectedType = ChatSystemType::GALAXY;
+        return true;
+    }
+    if (ContainsChatSystemKeyword(token, "planet")) {
+        detectedType = ChatSystemType::PLANET;
+        return true;
+    }
+    if (ContainsChatSystemKeyword(token, "spatial")) {
+        detectedType = ChatSystemType::SPATIAL;
+        return true;
+    }
+    return false;
+}
+
+inline ChatSystemType DetermineChatSystem(const std::u16string& roomName, const std::u16string& roomAddress) {
+    const auto normalizedName = NormalizeChatSystemToken(roomName);
+    const auto normalizedAddress = NormalizeChatSystemToken(roomAddress);
+
+    ChatSystemType nameType = ChatSystemType::SPATIAL;
+    ChatSystemType addressType = ChatSystemType::SPATIAL;
+
+    const bool hasNameDetection = DetectChatSystem(normalizedName, nameType);
+    const bool hasAddressDetection = DetectChatSystem(normalizedAddress, addressType);
+
+    if ((hasNameDetection && nameType == ChatSystemType::GALAXY)
+        || (hasAddressDetection && addressType == ChatSystemType::GALAXY)) {
+        return ChatSystemType::GALAXY;
+    }
+
+    if ((hasNameDetection && nameType == ChatSystemType::PLANET)
+        || (hasAddressDetection && addressType == ChatSystemType::PLANET)) {
+        return ChatSystemType::PLANET;
+    }
+
+    if ((hasNameDetection && nameType == ChatSystemType::SPATIAL)
+        || (hasAddressDetection && addressType == ChatSystemType::SPATIAL)) {
+        return ChatSystemType::SPATIAL;
+    }
+
+    return ChatSystemType::SPATIAL;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,9 +3,10 @@ include_directories(${PROJECT_SOURCE_DIR}/externals/catch
 
 add_executable(stationapi_tests
     main.cpp
-    
+
     stationapi/Serialization_Tests.cpp
-    stationapi/StringUtils_Tests.cpp)
+    stationapi/StringUtils_Tests.cpp
+    stationchat/ChatSystem_Tests.cpp)
 
 target_link_libraries(stationapi_tests
     stationapi)

--- a/tests/stationchat/ChatSystem_Tests.cpp
+++ b/tests/stationchat/ChatSystem_Tests.cpp
@@ -1,0 +1,26 @@
+#include "catch.hpp"
+
+#include "stationchat/ChatEnums.hpp"
+#include "stationchat/ChatSystem.hpp"
+
+TEST_CASE("Chat system detection defaults to spatial", "[chat][system]") {
+    auto type = DetermineChatSystem(u"Cantina", u"swg+server+cantina");
+    REQUIRE(type == ChatSystemType::SPATIAL);
+}
+
+TEST_CASE("Chat system detection recognizes planet channels", "[chat][system]") {
+    auto type = DetermineChatSystem(u"Planet Naboo", u"swg+planet+naboo");
+    REQUIRE(type == ChatSystemType::PLANET);
+}
+
+TEST_CASE("Chat system detection recognizes galaxy channels", "[chat][system]") {
+    auto type = DetermineChatSystem(u"Galaxy Broadcast", u"swg+galaxy+broadcast");
+    REQUIRE(type == ChatSystemType::GALAXY);
+}
+
+TEST_CASE("Chat system node level normalization", "[chat][system]") {
+    REQUIRE(ChatSystemFromNodeLevel(static_cast<uint32_t>(ChatSystemType::GALAXY))
+        == ChatSystemType::GALAXY);
+    REQUIRE(ChatSystemFromNodeLevel(42) == ChatSystemType::SPATIAL);
+    REQUIRE(NodeLevelFromChatSystem(ChatSystemType::PLANET) == 1u);
+}


### PR DESCRIPTION
## Summary
- add a ChatSystemType enum to represent spatial, planet, and galaxy scopes
- classify chat rooms by inspecting their names/addresses and persist the node level
- cover the classification helper with unit tests and expose the new header to the build

## Testing
- cmake -S . -B build *(fails: udplibrary dependency is missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa62d6676c832caa2cbfba327b8db8