### PR TITLE
Fix chat room storage query and add regression test

### DIFF
--- a/src/stationchat/ChatRoomService.cpp
+++ b/src/stationchat/ChatRoomService.cpp
@@ -19,7 +19,7 @@ void ChatRoomService::LoadRoomsFromStorage(const std::u16string& baseAddress) {
 
     char sql[] = "SELECT id, creator_id, creator_name, creator_address, room_name, room_topic, "
                  "room_password, room_prefix, room_address, room_attributes, room_max_size, "
-                 "room_message_id, created_at, node_level FROM room WHERE room_address LIKE @baseAddress||'%'";
+                 "room_message_id, created_at, node_level FROM room WHERE room_address LIKE CONCAT(@baseAddress, '%')";
 
     if (mariadb_prepare(db_, sql, -1, &stmt, 0) != MARIADB_OK) {
         throw std::runtime_error("Error preparing SQL statement");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,9 +3,28 @@ include_directories(${PROJECT_SOURCE_DIR}/externals/catch
 
 add_executable(stationapi_tests
     main.cpp
-    
+
     stationapi/Serialization_Tests.cpp
     stationapi/StringUtils_Tests.cpp)
 
 target_link_libraries(stationapi_tests
     stationapi)
+
+add_executable(stationchat_tests
+    main.cpp
+
+    stationchat/ChatRoomService_Tests.cpp
+    stationchat/StubChatAvatarService.cpp
+    stationchat/FakeMariaDB.cpp
+
+    ${PROJECT_SOURCE_DIR}/src/stationchat/ChatRoomService.cpp
+    ${PROJECT_SOURCE_DIR}/src/stationchat/ChatRoom.cpp
+    ${PROJECT_SOURCE_DIR}/src/stationchat/ChatAvatar.cpp
+    ${PROJECT_SOURCE_DIR}/src/stationchat/ChatEnums.cpp
+    ${PROJECT_SOURCE_DIR}/src/stationapi/StringUtils.cpp
+    ${PROJECT_SOURCE_DIR}/src/stationapi/StreamUtils.cpp)
+
+target_include_directories(stationchat_tests PRIVATE
+    ${PROJECT_SOURCE_DIR}/src
+    ${PROJECT_SOURCE_DIR}/externals/catch
+    ${PROJECT_SOURCE_DIR}/externals/easyloggingpp)

--- a/tests/stationchat/ChatRoomService_Tests.cpp
+++ b/tests/stationchat/ChatRoomService_Tests.cpp
@@ -1,0 +1,55 @@
+#include "ChatRoomService.hpp"
+
+#include "FakeMariaDB.hpp"
+
+#include "catch.hpp"
+
+#include <string>
+
+namespace {
+
+FakeRoomRow MakeRoomRow(int id, const std::string& roomAddress, const std::string& roomName) {
+    FakeRoomRow row;
+    row.id = id;
+    row.creatorId = id * 10;
+    row.creatorName = "creator" + std::to_string(id);
+    row.creatorAddress = "addr" + std::to_string(id);
+    row.roomName = roomName;
+    row.roomTopic = "topic" + std::to_string(id);
+    row.roomPassword = "";
+    row.roomPrefix = "";
+    row.roomAddress = roomAddress;
+    row.roomAttributes = 0;
+    row.roomMaxSize = 50;
+    row.roomMessageId = 0;
+    row.createdAt = 0;
+    row.nodeLevel = 0;
+    return row;
+}
+
+}
+
+TEST_CASE("LoadRoomsFromStorage filters by base address prefix", "[stationchat]") {
+    MariaDBConnection db;
+    db.roomRows.push_back(MakeRoomRow(1, "base+alpha", "alpha"));
+    db.roomRows.push_back(MakeRoomRow(2, "base+beta", "beta"));
+    db.roomRows.push_back(MakeRoomRow(3, "other+gamma", "gamma"));
+
+    ChatRoomService service{nullptr, &db};
+
+    service.LoadRoomsFromStorage(u"base");
+
+    REQUIRE(db.lastPreparedSql.find("LIKE CONCAT(@baseAddress, '%')") != std::string::npos);
+
+    auto* alpha = service.GetRoom(u"base+alpha");
+    auto* beta = service.GetRoom(u"base+beta");
+    auto* gamma = service.GetRoom(u"other+gamma");
+
+    REQUIRE(alpha != nullptr);
+    REQUIRE(beta != nullptr);
+    REQUIRE(gamma == nullptr);
+
+    CHECK(alpha->GetRoomName() == std::u16string{u"alpha"});
+    CHECK(beta->GetRoomName() == std::u16string{u"beta"});
+}
+

--- a/tests/stationchat/FakeMariaDB.cpp
+++ b/tests/stationchat/FakeMariaDB.cpp
@@ -1,0 +1,238 @@
+#include "FakeMariaDB.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+
+struct MariaDBStatement {
+    MariaDBConnection* connection{nullptr};
+    std::string sql;
+    std::optional<std::string> baseAddress;
+    std::vector<const FakeRoomRow*> matchedRows;
+    std::size_t currentIndex{0};
+    const FakeRoomRow* currentRow{nullptr};
+    bool prepared{false};
+};
+
+int mariadb_open(const char*, MariaDBConnection** db) {
+    if (!db) {
+        return MARIADB_ERROR;
+    }
+    *db = new MariaDBConnection();
+    return MARIADB_OK;
+}
+
+int mariadb_close(MariaDBConnection* db) {
+    delete db;
+    return MARIADB_OK;
+}
+
+const char* mariadb_errmsg(MariaDBConnection* db) {
+    static const char* defaultMessage = "Unknown MariaDB error";
+    if (!db) {
+        return defaultMessage;
+    }
+    return db->lastError.c_str();
+}
+
+int mariadb_prepare(MariaDBConnection* db, const char* sql, int, MariaDBStatement** stmt, const char**) {
+    if (!db || !sql || !stmt) {
+        return MARIADB_ERROR;
+    }
+
+    auto* statement = new MariaDBStatement();
+    statement->connection = db;
+    statement->sql = sql;
+    db->lastPreparedSql = sql;
+    db->lastError = "OK";
+
+    *stmt = statement;
+    return MARIADB_OK;
+}
+
+int mariadb_bind_parameter_index(MariaDBStatement*, const char* parameterName) {
+    if (!parameterName) {
+        return 0;
+    }
+
+    std::string name{parameterName};
+    if (!name.empty() && name.front() == '@') {
+        name.erase(name.begin());
+    }
+
+    if (name == "baseAddress") {
+        return 1;
+    }
+
+    return 0;
+}
+
+int mariadb_bind_int(MariaDBStatement*, int, int) {
+    return MARIADB_OK;
+}
+
+int mariadb_bind_text(MariaDBStatement* stmt, int index, const char* value, int length, void (*)(void*)) {
+    if (!stmt || index != 1) {
+        return MARIADB_ERROR;
+    }
+
+    if (!value) {
+        stmt->baseAddress.reset();
+        return MARIADB_OK;
+    }
+
+    if (length < 0) {
+        length = static_cast<int>(std::strlen(value));
+    }
+
+    stmt->baseAddress = std::string(value, static_cast<std::size_t>(length));
+    return MARIADB_OK;
+}
+
+int mariadb_bind_blob(MariaDBStatement*, int, const void*, int, void (*)(void*)) {
+    return MARIADB_OK;
+}
+
+int mariadb_step(MariaDBStatement* stmt) {
+    if (!stmt || !stmt->connection) {
+        return MARIADB_ERROR;
+    }
+
+    if (!stmt->prepared) {
+        stmt->prepared = true;
+        stmt->currentIndex = 0;
+        stmt->matchedRows.clear();
+
+        if (!stmt->baseAddress.has_value()) {
+            stmt->connection->lastError = "baseAddress not bound";
+            return MARIADB_ERROR;
+        }
+
+        const std::string& prefix = *stmt->baseAddress;
+        for (const auto& row : stmt->connection->roomRows) {
+            if (row.roomAddress.rfind(prefix, 0) == 0) {
+                stmt->matchedRows.push_back(&row);
+            }
+        }
+    }
+
+    if (stmt->currentIndex >= stmt->matchedRows.size()) {
+        stmt->currentRow = nullptr;
+        stmt->connection->lastError = "OK";
+        return MARIADB_DONE;
+    }
+
+    stmt->currentRow = stmt->matchedRows[stmt->currentIndex++];
+    stmt->connection->lastError = "OK";
+    return MARIADB_ROW;
+}
+
+int mariadb_finalize(MariaDBStatement* stmt) {
+    delete stmt;
+    return MARIADB_OK;
+}
+
+int mariadb_column_int(MariaDBStatement* stmt, int column) {
+    if (!stmt || !stmt->currentRow) {
+        return 0;
+    }
+
+    switch (column) {
+    case 0:
+        return stmt->currentRow->id;
+    case 1:
+        return stmt->currentRow->creatorId;
+    case 9:
+        return stmt->currentRow->roomAttributes;
+    case 10:
+        return stmt->currentRow->roomMaxSize;
+    case 11:
+        return stmt->currentRow->roomMessageId;
+    case 12:
+        return stmt->currentRow->createdAt;
+    case 13:
+        return stmt->currentRow->nodeLevel;
+    default:
+        return 0;
+    }
+}
+
+const unsigned char* mariadb_column_text(MariaDBStatement* stmt, int column) {
+    if (!stmt || !stmt->currentRow) {
+        return nullptr;
+    }
+
+    const std::string* value = nullptr;
+
+    switch (column) {
+    case 2:
+        value = &stmt->currentRow->creatorName;
+        break;
+    case 3:
+        value = &stmt->currentRow->creatorAddress;
+        break;
+    case 4:
+        value = &stmt->currentRow->roomName;
+        break;
+    case 5:
+        value = &stmt->currentRow->roomTopic;
+        break;
+    case 6:
+        value = &stmt->currentRow->roomPassword;
+        break;
+    case 7:
+        value = &stmt->currentRow->roomPrefix;
+        break;
+    case 8:
+        value = &stmt->currentRow->roomAddress;
+        break;
+    default:
+        return nullptr;
+    }
+
+    return reinterpret_cast<const unsigned char*>(value->c_str());
+}
+
+const void* mariadb_column_blob(MariaDBStatement*, int) { return nullptr; }
+
+int mariadb_column_bytes(MariaDBStatement* stmt, int column) {
+    if (!stmt || !stmt->currentRow) {
+        return 0;
+    }
+
+    const std::string* value = nullptr;
+
+    switch (column) {
+    case 2:
+        value = &stmt->currentRow->creatorName;
+        break;
+    case 3:
+        value = &stmt->currentRow->creatorAddress;
+        break;
+    case 4:
+        value = &stmt->currentRow->roomName;
+        break;
+    case 5:
+        value = &stmt->currentRow->roomTopic;
+        break;
+    case 6:
+        value = &stmt->currentRow->roomPassword;
+        break;
+    case 7:
+        value = &stmt->currentRow->roomPrefix;
+        break;
+    case 8:
+        value = &stmt->currentRow->roomAddress;
+        break;
+    default:
+        return 0;
+    }
+
+    return static_cast<int>(value->size());
+}
+
+std::int64_t mariadb_last_insert_rowid(MariaDBConnection*) {
+    return 0;
+}
+

--- a/tests/stationchat/FakeMariaDB.hpp
+++ b/tests/stationchat/FakeMariaDB.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "MariaDB.hpp"
+
+#include <string>
+#include <vector>
+
+struct FakeRoomRow {
+    int id{0};
+    int creatorId{0};
+    std::string creatorName;
+    std::string creatorAddress;
+    std::string roomName;
+    std::string roomTopic;
+    std::string roomPassword;
+    std::string roomPrefix;
+    std::string roomAddress;
+    int roomAttributes{0};
+    int roomMaxSize{0};
+    int roomMessageId{0};
+    int createdAt{0};
+    int nodeLevel{0};
+};
+
+struct MariaDBConnection {
+    std::vector<FakeRoomRow> roomRows;
+    std::string lastError{"OK"};
+    std::string lastPreparedSql;
+};
+

--- a/tests/stationchat/StubChatAvatarService.cpp
+++ b/tests/stationchat/StubChatAvatarService.cpp
@@ -1,0 +1,34 @@
+#include "ChatAvatarService.hpp"
+
+ChatAvatarService::ChatAvatarService(MariaDBConnection* db)
+    : db_{db} {}
+
+ChatAvatarService::~ChatAvatarService() = default;
+
+ChatAvatar* ChatAvatarService::GetAvatar(const std::u16string&, const std::u16string&) { return nullptr; }
+
+ChatAvatar* ChatAvatarService::GetAvatar(uint32_t) { return nullptr; }
+
+ChatAvatar* ChatAvatarService::CreateAvatar(const std::u16string&, const std::u16string&, uint32_t, uint32_t,
+    const std::u16string&) {
+    return nullptr;
+}
+
+void ChatAvatarService::DestroyAvatar(ChatAvatar*) {}
+
+void ChatAvatarService::LoginAvatar(ChatAvatar*) {}
+
+void ChatAvatarService::LogoutAvatar(ChatAvatar*) {}
+
+void ChatAvatarService::PersistAvatar(const ChatAvatar*) {}
+
+void ChatAvatarService::PersistFriend(uint32_t, uint32_t, const std::u16string&) {}
+
+void ChatAvatarService::PersistIgnore(uint32_t, uint32_t) {}
+
+void ChatAvatarService::RemoveFriend(uint32_t, uint32_t) {}
+
+void ChatAvatarService::RemoveIgnore(uint32_t, uint32_t) {}
+
+void ChatAvatarService::UpdateFriendComment(uint32_t, uint32_t, const std::u16string&) {}
+


### PR DESCRIPTION
## Summary
- update ChatRoomService to query MariaDB with CONCAT when filtering by base address
- add a fake MariaDB implementation and regression test that ensures rooms with the base prefix are loaded
- hook the new stationchat regression test into the test CMake configuration

## Testing
- cmake -S . -B build *(fails: udplibrary required in externals)*

------
https://chatgpt.com/codex/tasks/task_e_68fb63872b44832cbf936b4011c5faeb