### PR TITLE
Improve UTF-8 conversions for chat room loading

### DIFF
--- a/src/stationapi/StringUtils.cpp
+++ b/src/stationapi/StringUtils.cpp
@@ -1,10 +1,24 @@
+#include "StringUtils.hpp"
 
-#include "StreamUtils.hpp"
+#include <codecvt>
+#include <locale>
+#include <optional>
 
 std::string FromWideString(const std::u16string& str) {
-    return std::string{std::begin(str), std::end(str)};
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> converter;
+    return converter.to_bytes(str);
 }
 
 std::u16string ToWideString(const std::string& str) {
-    return std::u16string{std::begin(str), std::end(str)};
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> converter;
+    return converter.from_bytes(str);
+}
+
+std::optional<std::u16string> NullableUtf8ToWide(const unsigned char* buffer) {
+    if (!buffer) {
+        return std::nullopt;
+    }
+
+    const auto utf8 = reinterpret_cast<const char*>(buffer);
+    return ToWideString(utf8);
 }

--- a/src/stationapi/StringUtils.hpp
+++ b/src/stationapi/StringUtils.hpp
@@ -1,8 +1,9 @@
-
 #pragma once
 
+#include <optional>
 #include <string>
 
 std::string FromWideString(const std::u16string& str);
-
 std::u16string ToWideString(const std::string& str);
+std::optional<std::u16string> NullableUtf8ToWide(const unsigned char* buffer);
+

--- a/tests/stationapi/StringUtils_Tests.cpp
+++ b/tests/stationapi/StringUtils_Tests.cpp
@@ -11,7 +11,7 @@ SCENARIO("string widths can be converted to and from 8 and 16 bits", "[strings]"
 
         WHEN("the width is converted to wide") {
             auto wideStr = ToWideString(narrowStr);
-            
+
             THEN("the length of the new string is the same as the narrow string") {
                 REQUIRE(wideStr.length() == narrowStr.length());
             }
@@ -37,6 +37,41 @@ SCENARIO("string widths can be converted to and from 8 and 16 bits", "[strings]"
 
             AND_THEN("the contents of the new string is equivalent to the wide string") {
                 REQUIRE(narrowStr.compare("Some string text here.") == 0);
+            }
+        }
+    }
+
+    GIVEN("a UTF-8 string that requires multibyte characters") {
+        std::string multibyte = u8"こんにちは世界"; // "Hello, world" in Japanese.
+
+        WHEN("the width is converted to wide") {
+            auto wideStr = ToWideString(multibyte);
+
+            THEN("converting back preserves the original contents") {
+                auto roundTripped = FromWideString(wideStr);
+                REQUIRE(roundTripped == multibyte);
+            }
+        }
+    }
+
+    GIVEN("a nullable UTF-8 buffer") {
+        std::string utf8 = u8"StationAPI 🚀";
+        const auto* buffer = reinterpret_cast<const unsigned char*>(utf8.c_str());
+
+        WHEN("the buffer is not null") {
+            auto converted = NullableUtf8ToWide(buffer);
+
+            THEN("an equivalent wide string is returned") {
+                REQUIRE(converted.has_value());
+                REQUIRE(FromWideString(*converted) == utf8);
+            }
+        }
+
+        WHEN("the buffer is null") {
+            auto converted = NullableUtf8ToWide(nullptr);
+
+            THEN("no string is produced") {
+                REQUIRE_FALSE(converted.has_value());
             }
         }
     }


### PR DESCRIPTION
## Summary
- replace narrow-to-wide string conversions with UTF-8 aware helpers
- add a helper that safely converts nullable UTF-8 buffers to UTF-16 strings
- expand unit tests to cover multibyte UTF-8 input and NULL buffer handling

## Testing
- `cmake -S . -B build` *(fails: udplibrary dependency missing in externals directory)*

------
https://chatgpt.com/codex/tasks/task_e_68fb63c4bcf0832c88763d0f7494416b