### PR TITLE
Use unique_ptr to manage UdpManager lifetime

### DIFF
--- a/src/stationapi/Node.hpp
+++ b/src/stationapi/Node.hpp
@@ -7,12 +7,27 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 #include <stdexcept>
 
 template <typename NodeT, typename ClientT>
 class Node : public UdpManagerHandler
 {
+private:
+    struct UdpManagerDeleter
+    {
+        void operator()(UdpManager *manager) const noexcept
+        {
+            if (manager != nullptr)
+            {
+                manager->Release();
+            }
+        }
+    };
+
+    using UdpManagerPtr = std::unique_ptr<UdpManager, UdpManagerDeleter>;
+
 public:
     explicit Node(NodeT *node, const std::string &listenAddress, uint16_t listenPort, bool bindToIp = false)
         : node_{node}
@@ -32,10 +47,9 @@ public:
             std::copy(std::begin(listenAddress), std::end(listenAddress), params.bindIpAddress);
         }
 
-        udpManager_ = new UdpManager(&params);
+        UdpManagerPtr udpManager{new UdpManager(&params)};
+        udpManager_ = std::move(udpManager);
     }
-
-    virtual ~Node() { udpManager_->Release(); }
 
     void Tick()
     {
@@ -62,5 +76,5 @@ private:
 
     std::vector<std::unique_ptr<ClientT>> clients_;
     NodeT *node_;
-    UdpManager *udpManager_;
+    UdpManagerPtr udpManager_;
 };


### PR DESCRIPTION
## Summary
- replace the manual UdpManager pointer in `Node` with a `std::unique_ptr` and custom deleter that calls `Release`
- construct `UdpManager` through the smart pointer to prevent leaks if initialization throws

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb6b590b20832ca4c215b1f44a63a6