### PR TITLE
Add regression suites for stationchat services

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,30 @@ To remove build artifacts created by either approach, run:
 swg@raspberrypi:~/stationapi $ ant clean
 ```
 
+## 🧪 Testing
+
+Catch2-based regression suites live under `tests/` and can be built alongside
+the gateway. The default CMake configuration produces a dedicated binary for the
+chat modules:
+
+```bash
+cmake --build build --target stationchat_tests
+./build/tests/stationchat_tests -r compact
+```
+
+The executable covers:
+
+- `ChatRoomService` room creation flows, including duplicate detection and
+  UTF-8 persistence checks.
+- `PersistentMessageService` storage/retrieval, guaranteeing multi-byte headers
+  survive round-trips and status transitions.
+- `WebsiteIntegrationService` synchronisation paths, ensuring website mirroring
+  honours the enable/disable toggle and updates user link, presence, and mail
+  records.
+
+Running the binary with `--help` lists additional Catch2 filters if you want to
+target an individual suite.
+
 🗄️ Database Setup
 
 ### Provisioning MariaDB on `192.168.88.6`

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,8 @@ add_executable(stationchat_tests
     main.cpp
 
     stationchat/ChatRoomService_Tests.cpp
+    stationchat/PersistentMessageService_Tests.cpp
+    stationchat/WebsiteIntegrationService_Tests.cpp
     stationchat/StubChatAvatarService.cpp
     stationchat/FakeMariaDB.cpp
 
@@ -22,6 +24,8 @@ add_executable(stationchat_tests
     ${PROJECT_SOURCE_DIR}/src/stationchat/ChatRoom.cpp
     ${PROJECT_SOURCE_DIR}/src/stationchat/ChatAvatar.cpp
     ${PROJECT_SOURCE_DIR}/src/stationchat/ChatEnums.cpp
+    ${PROJECT_SOURCE_DIR}/src/stationchat/PersistentMessageService.cpp
+    ${PROJECT_SOURCE_DIR}/src/stationchat/WebsiteIntegrationService.cpp
     ${PROJECT_SOURCE_DIR}/src/stationapi/StringUtils.cpp
     ${PROJECT_SOURCE_DIR}/src/stationapi/StreamUtils.cpp)
 

--- a/tests/stationchat/FakeMariaDB.cpp
+++ b/tests/stationchat/FakeMariaDB.cpp
@@ -1,19 +1,278 @@
 #include "FakeMariaDB.hpp"
 
+#include "PersistentMessage.hpp"
+
 #include <algorithm>
-#include <cstdint>
 #include <cstring>
-#include <optional>
+#include <unordered_map>
+
+namespace {
+
+enum class StatementType {
+    Unknown,
+    SelectRooms,
+    InsertRoom,
+    InsertPersistentMessage,
+    SelectPersistentHeaders,
+    SelectPersistentMessage,
+    UpdatePersistentStatus,
+    BulkUpdatePersistentStatus,
+    WebsiteUserLink,
+    WebsiteOnlineStatus,
+    WebsiteMail,
+    ShowColumns,
+};
+
+struct BoundValue {
+    enum class Kind { None, Int, Text, Blob };
+
+    Kind kind{Kind::None};
+    int intValue{0};
+    std::optional<std::string> textValue;
+    std::vector<uint8_t> blobValue;
+    bool isNull{false};
+};
 
 struct MariaDBStatement {
     MariaDBConnection* connection{nullptr};
     std::string sql;
-    std::optional<std::string> baseAddress;
-    std::vector<const FakeRoomRow*> matchedRows;
-    std::size_t currentIndex{0};
-    const FakeRoomRow* currentRow{nullptr};
+    StatementType type{StatementType::Unknown};
+    std::string tableName;
     bool prepared{false};
+    std::size_t currentIndex{0};
+    std::vector<const FakeRoomRow*> matchedRooms;
+    std::vector<const FakePersistentMessageRow*> matchedMessages;
+    const FakeRoomRow* currentRoom{nullptr};
+    const FakePersistentMessageRow* currentMessage{nullptr};
+    const FakeColumnDefinition* columnDefinition{nullptr};
+    std::string columnName;
+    bool returnedColumn{false};
+    std::unordered_map<std::string, int> parameterIndexes;
+    std::unordered_map<int, std::string> indexToName;
+    std::unordered_map<std::string, BoundValue> boundValues;
 };
+
+std::string NormalizeParameter(const char* name) {
+    if (!name) {
+        return {};
+    }
+
+    std::string normalized{name};
+    if (!normalized.empty() && normalized.front() == '@') {
+        normalized.erase(normalized.begin());
+    }
+    return normalized;
+}
+
+std::string ExtractTableName(const std::string& sqlFragment) {
+    auto start = sqlFragment.find_first_not_of(' ');
+    if (start == std::string::npos) {
+        return {};
+    }
+
+    if (sqlFragment[start] == '`') {
+        auto end = sqlFragment.find('`', start + 1);
+        if (end == std::string::npos) {
+            return sqlFragment.substr(start + 1);
+        }
+        return sqlFragment.substr(start + 1, end - start - 1);
+    }
+
+    auto end = sqlFragment.find_first_of(" (\t\n");
+    if (end == std::string::npos) {
+        return sqlFragment.substr(start);
+    }
+    return sqlFragment.substr(start, end - start);
+}
+
+StatementType IdentifyStatement(const std::string& sql, MariaDBConnection* connection, std::string& tableName) {
+    if (sql.find("room_address LIKE CONCAT") != std::string::npos) {
+        return StatementType::SelectRooms;
+    }
+
+    if (sql.find("INSERT INTO room ") != std::string::npos) {
+        tableName = "room";
+        return StatementType::InsertRoom;
+    }
+
+    if (sql.find("INSERT INTO persistent_message") != std::string::npos) {
+        tableName = "persistent_message";
+        return StatementType::InsertPersistentMessage;
+    }
+
+    if (sql.find("FROM persistent_message WHERE avatar_id = @avatar_id") != std::string::npos
+        && sql.find("status IN (1, 2, 3)") != std::string::npos) {
+        tableName = "persistent_message";
+        return StatementType::SelectPersistentHeaders;
+    }
+
+    if (sql.find("FROM persistent_message WHERE id = @message_id") != std::string::npos) {
+        tableName = "persistent_message";
+        return StatementType::SelectPersistentMessage;
+    }
+
+    if (sql.find("UPDATE persistent_message SET status = @status WHERE id = @message_id") != std::string::npos) {
+        tableName = "persistent_message";
+        return StatementType::UpdatePersistentStatus;
+    }
+
+    if (sql.find("UPDATE persistent_message SET status = @status WHERE avatar_id = @avatar_id") != std::string::npos
+        && sql.find("category = @category") != std::string::npos) {
+        tableName = "persistent_message";
+        return StatementType::BulkUpdatePersistentStatus;
+    }
+
+    if (sql.rfind("SHOW COLUMNS FROM ", 0) == 0) {
+        tableName = ExtractTableName(sql.substr(std::strlen("SHOW COLUMNS FROM ")));
+        return StatementType::ShowColumns;
+    }
+
+    if (sql.rfind("INSERT INTO ", 0) == 0 && connection) {
+        auto fragment = sql.substr(std::strlen("INSERT INTO "));
+        tableName = ExtractTableName(fragment);
+
+        if (!connection->userLinkTableName.empty()
+            && fragment.find(connection->userLinkTableName) != std::string::npos) {
+            return StatementType::WebsiteUserLink;
+        }
+
+        if (!connection->onlineStatusTableName.empty()
+            && fragment.find(connection->onlineStatusTableName) != std::string::npos) {
+            return StatementType::WebsiteOnlineStatus;
+        }
+
+        if (!connection->mailTableName.empty()
+            && fragment.find(connection->mailTableName) != std::string::npos) {
+            return StatementType::WebsiteMail;
+        }
+    }
+
+    return StatementType::Unknown;
+}
+
+BoundValue* GetBoundValue(MariaDBStatement* stmt, int index) {
+    if (!stmt || index <= 0) {
+        return nullptr;
+    }
+
+    auto nameIt = stmt->indexToName.find(index);
+    if (nameIt == std::end(stmt->indexToName)) {
+        return nullptr;
+    }
+
+    return &stmt->boundValues[nameIt->second];
+}
+
+const BoundValue* FindBoundValue(const MariaDBStatement* stmt, const std::string& name) {
+    if (!stmt) {
+        return nullptr;
+    }
+
+    auto valueIt = stmt->boundValues.find(name);
+    if (valueIt == std::end(stmt->boundValues)) {
+        return nullptr;
+    }
+    return &valueIt->second;
+}
+
+int GetBoundInt(const MariaDBStatement* stmt, const std::string& name, int defaultValue = 0) {
+    auto value = FindBoundValue(stmt, name);
+    if (!value) {
+        return defaultValue;
+    }
+
+    if (value->kind == BoundValue::Kind::Int) {
+        return value->intValue;
+    }
+
+    if (value->kind == BoundValue::Kind::Text && value->textValue && !value->isNull) {
+        return std::stoi(*value->textValue);
+    }
+
+    return defaultValue;
+}
+
+std::optional<std::string> GetBoundText(const MariaDBStatement* stmt, const std::string& name) {
+    auto value = FindBoundValue(stmt, name);
+    if (!value || value->kind != BoundValue::Kind::Text || value->isNull) {
+        return std::nullopt;
+    }
+    return value->textValue;
+}
+
+FakeTimestampValue GetTimestampValue(const MariaDBStatement* stmt, const std::string& name) {
+    FakeTimestampValue result;
+    auto value = FindBoundValue(stmt, name);
+    if (!value) {
+        return result;
+    }
+
+    if (value->kind == BoundValue::Kind::Int) {
+        result.isNull = false;
+        result.intValue = value->intValue;
+    } else if (value->kind == BoundValue::Kind::Text) {
+        result.isNull = value->isNull;
+        if (!value->isNull && value->textValue) {
+            result.textValue = *value->textValue;
+        }
+    }
+
+    return result;
+}
+
+const std::vector<uint8_t>* GetBoundBlob(const MariaDBStatement* stmt, const std::string& name) {
+    auto value = FindBoundValue(stmt, name);
+    if (!value || value->kind != BoundValue::Kind::Blob) {
+        return nullptr;
+    }
+    return &value->blobValue;
+}
+
+FakePersistentMessageRow* FindPersistentMessage(MariaDBConnection* connection, uint32_t avatarId, uint32_t messageId) {
+    if (!connection) {
+        return nullptr;
+    }
+
+    auto it = std::find_if(std::begin(connection->persistentMessages), std::end(connection->persistentMessages),
+        [avatarId, messageId](const FakePersistentMessageRow& row) {
+            return row.avatarId == avatarId && row.id == messageId;
+        });
+
+    if (it == std::end(connection->persistentMessages)) {
+        return nullptr;
+    }
+
+    return &*it;
+}
+
+FakeUserLinkRow* FindUserLink(MariaDBConnection* connection, uint32_t avatarId) {
+    auto it = std::find_if(std::begin(connection->websiteUserLinks), std::end(connection->websiteUserLinks),
+        [avatarId](const FakeUserLinkRow& row) { return row.avatarId == avatarId; });
+    if (it == std::end(connection->websiteUserLinks)) {
+        return nullptr;
+    }
+    return &*it;
+}
+
+FakeStatusRow* FindStatusRow(MariaDBConnection* connection, uint32_t avatarId) {
+    auto it = std::find_if(std::begin(connection->websiteStatusRows), std::end(connection->websiteStatusRows),
+        [avatarId](const FakeStatusRow& row) { return row.avatarId == avatarId; });
+    if (it == std::end(connection->websiteStatusRows)) {
+        return nullptr;
+    }
+    return &*it;
+}
+
+FakeMailRow* FindMailRow(MariaDBConnection* connection, uint32_t messageId) {
+    auto it = std::find_if(std::begin(connection->websiteMailRows), std::end(connection->websiteMailRows),
+        [messageId](const FakeMailRow& row) { return row.messageId == messageId; });
+    if (it == std::end(connection->websiteMailRows)) {
+        return nullptr;
+    }
+    return &*it;
+}
+
+} // namespace
 
 int mariadb_open(const char*, MariaDBConnection** db) {
     if (!db) {
@@ -44,53 +303,78 @@ int mariadb_prepare(MariaDBConnection* db, const char* sql, int, MariaDBStatemen
     auto* statement = new MariaDBStatement();
     statement->connection = db;
     statement->sql = sql;
+    statement->type = IdentifyStatement(statement->sql, db, statement->tableName);
+
     db->lastPreparedSql = sql;
+    db->preparedSql.push_back(sql);
     db->lastError = "OK";
 
     *stmt = statement;
     return MARIADB_OK;
 }
 
-int mariadb_bind_parameter_index(MariaDBStatement*, const char* parameterName) {
-    if (!parameterName) {
+int mariadb_bind_parameter_index(MariaDBStatement* stmt, const char* parameterName) {
+    if (!stmt || !parameterName) {
         return 0;
     }
 
-    std::string name{parameterName};
-    if (!name.empty() && name.front() == '@') {
-        name.erase(name.begin());
+    auto name = NormalizeParameter(parameterName);
+    auto existing = stmt->parameterIndexes.find(name);
+    if (existing != std::end(stmt->parameterIndexes)) {
+        return existing->second;
     }
 
-    if (name == "baseAddress") {
-        return 1;
-    }
-
-    return 0;
+    int index = static_cast<int>(stmt->parameterIndexes.size()) + 1;
+    stmt->parameterIndexes.emplace(name, index);
+    stmt->indexToName.emplace(index, name);
+    return index;
 }
 
-int mariadb_bind_int(MariaDBStatement*, int, int) {
+int mariadb_bind_int(MariaDBStatement* stmt, int index, int value) {
+    auto bound = GetBoundValue(stmt, index);
+    if (!bound) {
+        return MARIADB_OK;
+    }
+
+    bound->kind = BoundValue::Kind::Int;
+    bound->intValue = value;
+    bound->isNull = false;
     return MARIADB_OK;
 }
 
 int mariadb_bind_text(MariaDBStatement* stmt, int index, const char* value, int length, void (*)(void*)) {
-    if (!stmt || index != 1) {
-        return MARIADB_ERROR;
-    }
-
-    if (!value) {
-        stmt->baseAddress.reset();
+    auto bound = GetBoundValue(stmt, index);
+    if (!bound) {
         return MARIADB_OK;
     }
 
+    bound->kind = BoundValue::Kind::Text;
+    if (!value) {
+        bound->isNull = true;
+        bound->textValue.reset();
+        return MARIADB_OK;
+    }
+
+    bound->isNull = false;
     if (length < 0) {
         length = static_cast<int>(std::strlen(value));
     }
-
-    stmt->baseAddress = std::string(value, static_cast<std::size_t>(length));
+    bound->textValue = std::string(value, static_cast<std::size_t>(length));
     return MARIADB_OK;
 }
 
-int mariadb_bind_blob(MariaDBStatement*, int, const void*, int, void (*)(void*)) {
+int mariadb_bind_blob(MariaDBStatement* stmt, int index, const void* value, int length, void (*)(void*)) {
+    auto bound = GetBoundValue(stmt, index);
+    if (!bound) {
+        return MARIADB_OK;
+    }
+
+    bound->kind = BoundValue::Kind::Blob;
+    bound->blobValue.clear();
+    if (value && length > 0) {
+        const auto* bytes = static_cast<const uint8_t*>(value);
+        bound->blobValue.assign(bytes, bytes + length);
+    }
     return MARIADB_OK;
 }
 
@@ -99,33 +383,261 @@ int mariadb_step(MariaDBStatement* stmt) {
         return MARIADB_ERROR;
     }
 
-    if (!stmt->prepared) {
-        stmt->prepared = true;
-        stmt->currentIndex = 0;
-        stmt->matchedRows.clear();
+    auto& connection = *stmt->connection;
+    connection.lastError = "OK";
 
-        if (!stmt->baseAddress.has_value()) {
-            stmt->connection->lastError = "baseAddress not bound";
-            return MARIADB_ERROR;
-        }
+    switch (stmt->type) {
+    case StatementType::SelectRooms: {
+        if (!stmt->prepared) {
+            stmt->prepared = true;
+            stmt->currentIndex = 0;
+            stmt->matchedRooms.clear();
+            stmt->currentRoom = nullptr;
 
-        const std::string& prefix = *stmt->baseAddress;
-        for (const auto& row : stmt->connection->roomRows) {
-            if (row.roomAddress.rfind(prefix, 0) == 0) {
-                stmt->matchedRows.push_back(&row);
+            auto baseAddress = GetBoundText(stmt, "baseAddress");
+            if (!baseAddress) {
+                connection.lastError = "baseAddress not bound";
+                return MARIADB_ERROR;
+            }
+
+            for (const auto& row : connection.roomRows) {
+                if (row.roomAddress.rfind(*baseAddress, 0) == 0) {
+                    stmt->matchedRooms.push_back(&row);
+                }
             }
         }
-    }
 
-    if (stmt->currentIndex >= stmt->matchedRows.size()) {
-        stmt->currentRow = nullptr;
-        stmt->connection->lastError = "OK";
+        if (stmt->currentIndex >= stmt->matchedRooms.size()) {
+            stmt->currentRoom = nullptr;
+            return MARIADB_DONE;
+        }
+
+        stmt->currentRoom = stmt->matchedRooms[stmt->currentIndex++];
+        return MARIADB_ROW;
+    }
+    case StatementType::InsertRoom: {
+        FakeRoomRow row;
+        row.id = static_cast<int>(connection.nextInsertId++);
+        row.creatorId = GetBoundInt(stmt, "creator_id");
+        row.creatorName = GetBoundText(stmt, "creator_name").value_or("");
+        row.creatorAddress = GetBoundText(stmt, "creator_address").value_or("");
+        row.roomName = GetBoundText(stmt, "room_name").value_or("");
+        row.roomTopic = GetBoundText(stmt, "room_topic").value_or("");
+        row.roomPassword = GetBoundText(stmt, "room_password").value_or("");
+        row.roomPrefix = GetBoundText(stmt, "room_prefix").value_or("");
+        row.roomAddress = GetBoundText(stmt, "room_address").value_or("");
+        row.roomAttributes = GetBoundInt(stmt, "room_attributes");
+        row.roomMaxSize = GetBoundInt(stmt, "room_max_size");
+        row.roomMessageId = GetBoundInt(stmt, "room_message_id");
+        row.createdAt = GetBoundInt(stmt, "created_at");
+        row.nodeLevel = GetBoundInt(stmt, "node_level");
+
+        connection.lastInsertId = row.id;
+        connection.insertedRooms.push_back(row);
         return MARIADB_DONE;
     }
+    case StatementType::InsertPersistentMessage: {
+        FakePersistentMessageRow row;
+        row.id = static_cast<uint32_t>(connection.nextInsertId++);
+        row.avatarId = static_cast<uint32_t>(GetBoundInt(stmt, "avatar_id"));
+        row.fromName = GetBoundText(stmt, "from_name").value_or("");
+        row.fromAddress = GetBoundText(stmt, "from_address").value_or("");
+        row.subject = GetBoundText(stmt, "subject").value_or("");
+        row.sentTime = static_cast<uint32_t>(GetBoundInt(stmt, "sent_time"));
+        row.status = static_cast<uint32_t>(GetBoundInt(stmt, "status"));
+        row.folder = GetBoundText(stmt, "folder").value_or("");
+        row.category = GetBoundText(stmt, "category").value_or("");
+        row.message = GetBoundText(stmt, "message").value_or("");
+        if (auto* blob = GetBoundBlob(stmt, "oob")) {
+            row.oob = *blob;
+        }
 
-    stmt->currentRow = stmt->matchedRows[stmt->currentIndex++];
-    stmt->connection->lastError = "OK";
-    return MARIADB_ROW;
+        connection.lastInsertId = row.id;
+        connection.persistentMessages.push_back(std::move(row));
+        return MARIADB_DONE;
+    }
+    case StatementType::SelectPersistentHeaders:
+    case StatementType::SelectPersistentMessage: {
+        if (!stmt->prepared) {
+            stmt->prepared = true;
+            stmt->matchedMessages.clear();
+            stmt->currentIndex = 0;
+            stmt->currentMessage = nullptr;
+
+            uint32_t avatarId = static_cast<uint32_t>(GetBoundInt(stmt, "avatar_id"));
+            if (stmt->type == StatementType::SelectPersistentHeaders) {
+                for (const auto& row : connection.persistentMessages) {
+                    if (row.avatarId == avatarId
+                        && (row.status == static_cast<uint32_t>(PersistentState::NEW)
+                            || row.status == static_cast<uint32_t>(PersistentState::UNREAD)
+                            || row.status == static_cast<uint32_t>(PersistentState::READ))) {
+                        stmt->matchedMessages.push_back(&row);
+                    }
+                }
+            } else {
+                uint32_t messageId = static_cast<uint32_t>(GetBoundInt(stmt, "message_id"));
+                for (const auto& row : connection.persistentMessages) {
+                    if (row.avatarId == avatarId && row.id == messageId) {
+                        stmt->matchedMessages.push_back(&row);
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (stmt->currentIndex >= stmt->matchedMessages.size()) {
+            stmt->currentMessage = nullptr;
+            return MARIADB_DONE;
+        }
+
+        stmt->currentMessage = stmt->matchedMessages[stmt->currentIndex++];
+        return MARIADB_ROW;
+    }
+    case StatementType::UpdatePersistentStatus: {
+        uint32_t avatarId = static_cast<uint32_t>(GetBoundInt(stmt, "avatar_id"));
+        uint32_t messageId = static_cast<uint32_t>(GetBoundInt(stmt, "message_id"));
+        auto* row = FindPersistentMessage(&connection, avatarId, messageId);
+        if (row) {
+            row->status = static_cast<uint32_t>(GetBoundInt(stmt, "status"));
+        }
+        return MARIADB_DONE;
+    }
+    case StatementType::BulkUpdatePersistentStatus: {
+        uint32_t avatarId = static_cast<uint32_t>(GetBoundInt(stmt, "avatar_id"));
+        auto category = GetBoundText(stmt, "category").value_or("");
+        auto newStatus = static_cast<uint32_t>(GetBoundInt(stmt, "status"));
+
+        for (auto& row : connection.persistentMessages) {
+            if (row.avatarId == avatarId && row.category == category) {
+                row.status = newStatus;
+            }
+        }
+        return MARIADB_DONE;
+    }
+    case StatementType::WebsiteUserLink: {
+        uint32_t avatarId = static_cast<uint32_t>(GetBoundInt(stmt, "avatar_id"));
+        uint32_t userId = static_cast<uint32_t>(GetBoundInt(stmt, "user_id"));
+        auto avatarName = GetBoundText(stmt, "avatar_name").value_or("");
+        auto createdAt = GetTimestampValue(stmt, "created_at");
+        auto updatedAt = GetTimestampValue(stmt, "updated_at");
+
+        auto* existing = FindUserLink(&connection, avatarId);
+        if (!existing) {
+            FakeUserLinkRow row;
+            row.avatarId = avatarId;
+            row.userId = userId;
+            row.avatarName = avatarName;
+            row.createdAt = createdAt;
+            row.updatedAt = updatedAt;
+            row.createdAt.isNull = createdAt.isNull;
+            row.updatedAt.isNull = updatedAt.isNull;
+            connection.websiteUserLinks.push_back(std::move(row));
+        } else {
+            existing->userId = userId;
+            existing->avatarName = avatarName;
+            if (!createdAt.isNull && (existing->createdAt.isNull)) {
+                existing->createdAt = createdAt;
+            }
+            if (!updatedAt.isNull) {
+                existing->updatedAt = updatedAt;
+            }
+        }
+        return MARIADB_DONE;
+    }
+    case StatementType::WebsiteOnlineStatus: {
+        uint32_t avatarId = static_cast<uint32_t>(GetBoundInt(stmt, "avatar_id"));
+        uint32_t userId = static_cast<uint32_t>(GetBoundInt(stmt, "user_id"));
+        auto avatarName = GetBoundText(stmt, "avatar_name").value_or("");
+        uint32_t isOnline = static_cast<uint32_t>(GetBoundInt(stmt, "is_online"));
+        auto lastLogin = GetTimestampValue(stmt, "last_login");
+        auto lastLogout = GetTimestampValue(stmt, "last_logout");
+        auto updatedAt = GetTimestampValue(stmt, "updated_at");
+        auto createdAt = GetTimestampValue(stmt, "created_at");
+
+        auto* existing = FindStatusRow(&connection, avatarId);
+        if (!existing) {
+            FakeStatusRow row;
+            row.avatarId = avatarId;
+            row.userId = userId;
+            row.avatarName = avatarName;
+            row.isOnline = isOnline;
+            row.lastLogin = lastLogin.intValue.value_or(0);
+            row.lastLogout = lastLogout.intValue.value_or(0);
+            row.createdAt = createdAt;
+            row.updatedAt = updatedAt;
+            connection.websiteStatusRows.push_back(std::move(row));
+        } else {
+            existing->userId = userId;
+            existing->avatarName = avatarName;
+            existing->isOnline = isOnline;
+
+            if (lastLogin.intValue && *lastLogin.intValue != 0) {
+                existing->lastLogin = *lastLogin.intValue;
+            }
+            if (lastLogout.intValue && *lastLogout.intValue != 0) {
+                existing->lastLogout = *lastLogout.intValue;
+            }
+            if (!updatedAt.isNull) {
+                existing->updatedAt = updatedAt;
+            }
+            if (existing->createdAt.isNull && !createdAt.isNull) {
+                existing->createdAt = createdAt;
+            }
+        }
+        return MARIADB_DONE;
+    }
+    case StatementType::WebsiteMail: {
+        FakeMailRow row;
+        row.avatarId = static_cast<uint32_t>(GetBoundInt(stmt, "avatar_id"));
+        row.userId = static_cast<uint32_t>(GetBoundInt(stmt, "user_id"));
+        row.avatarName = GetBoundText(stmt, "avatar_name").value_or("");
+        row.messageId = static_cast<uint32_t>(GetBoundInt(stmt, "message_id"));
+        row.senderName = GetBoundText(stmt, "sender_name").value_or("");
+        row.senderAddress = GetBoundText(stmt, "sender_address").value_or("");
+        row.subject = GetBoundText(stmt, "subject").value_or("");
+        row.body = GetBoundText(stmt, "body").value_or("");
+        row.oobText = GetBoundText(stmt, "oob").value_or("");
+        row.sentTime = static_cast<uint32_t>(GetBoundInt(stmt, "sent_time"));
+        row.createdAt = GetTimestampValue(stmt, "created_at");
+        row.updatedAt = GetTimestampValue(stmt, "updated_at");
+        row.status = static_cast<uint32_t>(GetBoundInt(stmt, "status"));
+
+        auto* existing = FindMailRow(&connection, row.messageId);
+        if (!existing) {
+            connection.websiteMailRows.push_back(std::move(row));
+        } else {
+            *existing = std::move(row);
+        }
+        return MARIADB_DONE;
+    }
+    case StatementType::ShowColumns: {
+        if (!stmt->prepared) {
+            stmt->prepared = true;
+            stmt->currentIndex = 0;
+            stmt->returnedColumn = false;
+            stmt->columnDefinition = nullptr;
+            stmt->columnName = GetBoundText(stmt, "column_name").value_or("");
+
+            auto tableIt = connection.columnDefinitions.find(stmt->tableName);
+            if (tableIt != std::end(connection.columnDefinitions)) {
+                auto columnIt = tableIt->second.find(stmt->columnName);
+                if (columnIt != std::end(tableIt->second) && columnIt->second.exists) {
+                    stmt->columnDefinition = &columnIt->second;
+                }
+            }
+        }
+
+        if (stmt->columnDefinition && !stmt->returnedColumn) {
+            stmt->returnedColumn = true;
+            return MARIADB_ROW;
+        }
+
+        return MARIADB_DONE;
+    }
+    case StatementType::Unknown:
+    default:
+        return MARIADB_ERROR;
+    }
 }
 
 int mariadb_finalize(MariaDBStatement* stmt) {
@@ -134,105 +646,186 @@ int mariadb_finalize(MariaDBStatement* stmt) {
 }
 
 int mariadb_column_int(MariaDBStatement* stmt, int column) {
-    if (!stmt || !stmt->currentRow) {
+    if (!stmt) {
         return 0;
     }
 
-    switch (column) {
-    case 0:
-        return stmt->currentRow->id;
-    case 1:
-        return stmt->currentRow->creatorId;
-    case 9:
-        return stmt->currentRow->roomAttributes;
-    case 10:
-        return stmt->currentRow->roomMaxSize;
-    case 11:
-        return stmt->currentRow->roomMessageId;
-    case 12:
-        return stmt->currentRow->createdAt;
-    case 13:
-        return stmt->currentRow->nodeLevel;
+    switch (stmt->type) {
+    case StatementType::SelectRooms:
+        if (!stmt->currentRoom) {
+            return 0;
+        }
+        switch (column) {
+        case 0:
+            return stmt->currentRoom->id;
+        case 1:
+            return stmt->currentRoom->creatorId;
+        case 9:
+            return stmt->currentRoom->roomAttributes;
+        case 10:
+            return stmt->currentRoom->roomMaxSize;
+        case 11:
+            return stmt->currentRoom->roomMessageId;
+        case 12:
+            return stmt->currentRoom->createdAt;
+        case 13:
+            return stmt->currentRoom->nodeLevel;
+        default:
+            return 0;
+        }
+    case StatementType::SelectPersistentHeaders:
+    case StatementType::SelectPersistentMessage:
+        if (!stmt->currentMessage) {
+            return 0;
+        }
+        switch (column) {
+        case 0:
+            return static_cast<int>(stmt->currentMessage->id);
+        case 1:
+            return static_cast<int>(stmt->currentMessage->avatarId);
+        case 5:
+            return static_cast<int>(stmt->currentMessage->sentTime);
+        case 6:
+            return static_cast<int>(stmt->currentMessage->status);
+        default:
+            return 0;
+        }
     default:
         return 0;
     }
 }
 
 const unsigned char* mariadb_column_text(MariaDBStatement* stmt, int column) {
-    if (!stmt || !stmt->currentRow) {
+    if (!stmt) {
         return nullptr;
     }
 
-    const std::string* value = nullptr;
-
-    switch (column) {
-    case 2:
-        value = &stmt->currentRow->creatorName;
-        break;
-    case 3:
-        value = &stmt->currentRow->creatorAddress;
-        break;
-    case 4:
-        value = &stmt->currentRow->roomName;
-        break;
-    case 5:
-        value = &stmt->currentRow->roomTopic;
-        break;
-    case 6:
-        value = &stmt->currentRow->roomPassword;
-        break;
-    case 7:
-        value = &stmt->currentRow->roomPrefix;
-        break;
-    case 8:
-        value = &stmt->currentRow->roomAddress;
-        break;
+    switch (stmt->type) {
+    case StatementType::SelectRooms:
+        if (!stmt->currentRoom) {
+            return nullptr;
+        }
+        switch (column) {
+        case 2:
+            return reinterpret_cast<const unsigned char*>(stmt->currentRoom->creatorName.c_str());
+        case 3:
+            return reinterpret_cast<const unsigned char*>(stmt->currentRoom->creatorAddress.c_str());
+        case 4:
+            return reinterpret_cast<const unsigned char*>(stmt->currentRoom->roomName.c_str());
+        case 5:
+            return reinterpret_cast<const unsigned char*>(stmt->currentRoom->roomTopic.c_str());
+        case 6:
+            return reinterpret_cast<const unsigned char*>(stmt->currentRoom->roomPassword.c_str());
+        case 7:
+            return reinterpret_cast<const unsigned char*>(stmt->currentRoom->roomPrefix.c_str());
+        case 8:
+            return reinterpret_cast<const unsigned char*>(stmt->currentRoom->roomAddress.c_str());
+        default:
+            return nullptr;
+        }
+    case StatementType::SelectPersistentHeaders:
+    case StatementType::SelectPersistentMessage:
+        if (!stmt->currentMessage) {
+            return nullptr;
+        }
+        switch (column) {
+        case 2:
+            return reinterpret_cast<const unsigned char*>(stmt->currentMessage->fromName.c_str());
+        case 3:
+            return reinterpret_cast<const unsigned char*>(stmt->currentMessage->fromAddress.c_str());
+        case 4:
+            return reinterpret_cast<const unsigned char*>(stmt->currentMessage->subject.c_str());
+        case 7:
+            return reinterpret_cast<const unsigned char*>(stmt->currentMessage->folder.c_str());
+        case 8:
+            return reinterpret_cast<const unsigned char*>(stmt->currentMessage->category.c_str());
+        case 9:
+            return reinterpret_cast<const unsigned char*>(stmt->currentMessage->message.c_str());
+        default:
+            return nullptr;
+        }
+    case StatementType::ShowColumns:
+        if (!stmt->columnDefinition || column != 1) {
+            return nullptr;
+        }
+        return reinterpret_cast<const unsigned char*>(stmt->columnDefinition->type.c_str());
     default:
         return nullptr;
     }
-
-    return reinterpret_cast<const unsigned char*>(value->c_str());
 }
 
-const void* mariadb_column_blob(MariaDBStatement*, int) { return nullptr; }
+const void* mariadb_column_blob(MariaDBStatement* stmt, int column) {
+    if (!stmt || stmt->type != StatementType::SelectPersistentMessage || !stmt->currentMessage) {
+        return nullptr;
+    }
+
+    if (column == 10) {
+        return stmt->currentMessage->oob.data();
+    }
+
+    return nullptr;
+}
 
 int mariadb_column_bytes(MariaDBStatement* stmt, int column) {
-    if (!stmt || !stmt->currentRow) {
+    if (!stmt) {
         return 0;
     }
 
-    const std::string* value = nullptr;
-
-    switch (column) {
-    case 2:
-        value = &stmt->currentRow->creatorName;
-        break;
-    case 3:
-        value = &stmt->currentRow->creatorAddress;
-        break;
-    case 4:
-        value = &stmt->currentRow->roomName;
-        break;
-    case 5:
-        value = &stmt->currentRow->roomTopic;
-        break;
-    case 6:
-        value = &stmt->currentRow->roomPassword;
-        break;
-    case 7:
-        value = &stmt->currentRow->roomPrefix;
-        break;
-    case 8:
-        value = &stmt->currentRow->roomAddress;
-        break;
+    switch (stmt->type) {
+    case StatementType::SelectRooms:
+        if (!stmt->currentRoom) {
+            return 0;
+        }
+        switch (column) {
+        case 2:
+            return static_cast<int>(stmt->currentRoom->creatorName.size());
+        case 3:
+            return static_cast<int>(stmt->currentRoom->creatorAddress.size());
+        case 4:
+            return static_cast<int>(stmt->currentRoom->roomName.size());
+        case 5:
+            return static_cast<int>(stmt->currentRoom->roomTopic.size());
+        case 6:
+            return static_cast<int>(stmt->currentRoom->roomPassword.size());
+        case 7:
+            return static_cast<int>(stmt->currentRoom->roomPrefix.size());
+        case 8:
+            return static_cast<int>(stmt->currentRoom->roomAddress.size());
+        default:
+            return 0;
+        }
+    case StatementType::SelectPersistentHeaders:
+    case StatementType::SelectPersistentMessage:
+        if (!stmt->currentMessage) {
+            return 0;
+        }
+        switch (column) {
+        case 2:
+            return static_cast<int>(stmt->currentMessage->fromName.size());
+        case 3:
+            return static_cast<int>(stmt->currentMessage->fromAddress.size());
+        case 4:
+            return static_cast<int>(stmt->currentMessage->subject.size());
+        case 7:
+            return static_cast<int>(stmt->currentMessage->folder.size());
+        case 8:
+            return static_cast<int>(stmt->currentMessage->category.size());
+        case 9:
+            return static_cast<int>(stmt->currentMessage->message.size());
+        case 10:
+            return static_cast<int>(stmt->currentMessage->oob.size());
+        default:
+            return 0;
+        }
     default:
         return 0;
     }
-
-    return static_cast<int>(value->size());
 }
 
-std::int64_t mariadb_last_insert_rowid(MariaDBConnection*) {
-    return 0;
+std::int64_t mariadb_last_insert_rowid(MariaDBConnection* db) {
+    if (!db) {
+        return 0;
+    }
+    return db->lastInsertId;
 }
 

--- a/tests/stationchat/FakeMariaDB.hpp
+++ b/tests/stationchat/FakeMariaDB.hpp
@@ -2,6 +2,9 @@
 
 #include "MariaDB.hpp"
 
+#include <cstdint>
+#include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -22,9 +25,82 @@ struct FakeRoomRow {
     int nodeLevel{0};
 };
 
+struct FakePersistentMessageRow {
+    uint32_t id{0};
+    uint32_t avatarId{0};
+    std::string fromName;
+    std::string fromAddress;
+    std::string subject;
+    uint32_t sentTime{0};
+    uint32_t status{0};
+    std::string folder;
+    std::string category;
+    std::string message;
+    std::vector<uint8_t> oob;
+};
+
+struct FakeTimestampValue {
+    bool isNull{true};
+    std::optional<int> intValue;
+    std::optional<std::string> textValue;
+};
+
+struct FakeUserLinkRow {
+    uint32_t userId{0};
+    uint32_t avatarId{0};
+    std::string avatarName;
+    FakeTimestampValue createdAt;
+    FakeTimestampValue updatedAt;
+};
+
+struct FakeStatusRow {
+    uint32_t avatarId{0};
+    uint32_t userId{0};
+    std::string avatarName;
+    uint32_t isOnline{0};
+    uint32_t lastLogin{0};
+    uint32_t lastLogout{0};
+    FakeTimestampValue createdAt;
+    FakeTimestampValue updatedAt;
+};
+
+struct FakeMailRow {
+    uint32_t avatarId{0};
+    uint32_t userId{0};
+    std::string avatarName;
+    uint32_t messageId{0};
+    std::string senderName;
+    std::string senderAddress;
+    std::string subject;
+    std::string body;
+    std::string oobText;
+    uint32_t sentTime{0};
+    FakeTimestampValue createdAt;
+    FakeTimestampValue updatedAt;
+    uint32_t status{0};
+};
+
+struct FakeColumnDefinition {
+    bool exists{false};
+    bool isDateTime{false};
+    std::string type;
+};
+
 struct MariaDBConnection {
     std::vector<FakeRoomRow> roomRows;
+    std::vector<FakeRoomRow> insertedRooms;
+    std::vector<FakePersistentMessageRow> persistentMessages;
+    std::vector<FakeUserLinkRow> websiteUserLinks;
+    std::vector<FakeStatusRow> websiteStatusRows;
+    std::vector<FakeMailRow> websiteMailRows;
+    std::map<std::string, std::map<std::string, FakeColumnDefinition>> columnDefinitions;
+    std::vector<std::string> preparedSql;
     std::string lastError{"OK"};
     std::string lastPreparedSql;
+    std::string userLinkTableName{"web_user_avatar"};
+    std::string onlineStatusTableName{"web_avatar_status"};
+    std::string mailTableName{"web_persistent_message"};
+    std::int64_t lastInsertId{0};
+    std::int64_t nextInsertId{1};
 };
 

--- a/tests/stationchat/PersistentMessageService_Tests.cpp
+++ b/tests/stationchat/PersistentMessageService_Tests.cpp
@@ -1,0 +1,49 @@
+#include "PersistentMessageService.hpp"
+
+#include "FakeMariaDB.hpp"
+#include "StringUtils.hpp"
+
+#include "catch.hpp"
+
+TEST_CASE("PersistentMessageService stores UTF-8 messages and updates status", "[stationchat]") {
+    MariaDBConnection db;
+    PersistentMessageService service{&db};
+
+    PersistentMessage message;
+    message.header.avatarId = 7;
+    message.header.fromName = u"Brontë";
+    message.header.fromAddress = u"ユニット";
+    message.header.subject = u"Invitation – déjà vu";
+    message.header.sentTime = 123456;
+    message.header.status = PersistentState::NEW;
+    message.header.folder = u"Inbox";
+    message.header.category = u"General";
+    message.message = u"こんにちは";
+    message.oob = u"☃";
+
+    service.StoreMessage(message);
+
+    REQUIRE(message.header.messageId != 0);
+    REQUIRE(db.persistentMessages.size() == 1);
+
+    const auto& storedRow = db.persistentMessages.front();
+    CHECK(storedRow.avatarId == message.header.avatarId);
+    CHECK(ToWideString(storedRow.fromName) == message.header.fromName);
+    CHECK(ToWideString(storedRow.subject) == message.header.subject);
+    CHECK(storedRow.status == static_cast<uint32_t>(PersistentState::NEW));
+
+    auto headers = service.GetMessageHeaders(message.header.avatarId);
+    REQUIRE(headers.size() == 1);
+    CHECK(headers.front().messageId == message.header.messageId);
+    CHECK(headers.front().subject == message.header.subject);
+
+    auto persisted = service.GetPersistentMessage(message.header.avatarId, message.header.messageId);
+    CHECK(persisted.header.messageId == message.header.messageId);
+    CHECK(persisted.header.status == PersistentState::READ);
+    CHECK(persisted.message == message.message);
+    CHECK(persisted.oob == message.oob);
+    CHECK(db.persistentMessages.front().status == static_cast<uint32_t>(PersistentState::READ));
+
+    service.BulkUpdateMessageStatus(message.header.avatarId, message.header.category, PersistentState::TRASH);
+    CHECK(db.persistentMessages.front().status == static_cast<uint32_t>(PersistentState::TRASH));
+}

--- a/tests/stationchat/StubChatAvatarService.cpp
+++ b/tests/stationchat/StubChatAvatarService.cpp
@@ -1,24 +1,77 @@
 #include "ChatAvatarService.hpp"
 
+#include <algorithm>
+#include <memory>
+
+namespace {
+uint32_t NextAvatarId() {
+    static uint32_t nextId = 1;
+    return nextId++;
+}
+}
+
 ChatAvatarService::ChatAvatarService(MariaDBConnection* db)
     : db_{db} {}
 
 ChatAvatarService::~ChatAvatarService() = default;
 
-ChatAvatar* ChatAvatarService::GetAvatar(const std::u16string&, const std::u16string&) { return nullptr; }
-
-ChatAvatar* ChatAvatarService::GetAvatar(uint32_t) { return nullptr; }
-
-ChatAvatar* ChatAvatarService::CreateAvatar(const std::u16string&, const std::u16string&, uint32_t, uint32_t,
-    const std::u16string&) {
-    return nullptr;
+ChatAvatar* ChatAvatarService::GetAvatar(const std::u16string& name, const std::u16string& address) {
+    auto it = std::find_if(std::begin(avatarCache_), std::end(avatarCache_),
+        [&](const auto& avatar) { return avatar->GetName() == name && avatar->GetAddress() == address; });
+    if (it == std::end(avatarCache_)) {
+        return nullptr;
+    }
+    return it->get();
 }
 
-void ChatAvatarService::DestroyAvatar(ChatAvatar*) {}
+ChatAvatar* ChatAvatarService::GetAvatar(uint32_t avatarId) {
+    auto it = std::find_if(std::begin(avatarCache_), std::end(avatarCache_),
+        [avatarId](const auto& avatar) { return avatar->GetAvatarId() == avatarId; });
+    if (it == std::end(avatarCache_)) {
+        return nullptr;
+    }
+    return it->get();
+}
 
-void ChatAvatarService::LoginAvatar(ChatAvatar*) {}
+ChatAvatar* ChatAvatarService::CreateAvatar(const std::u16string& name, const std::u16string& address, uint32_t userId,
+    uint32_t loginAttributes, const std::u16string& loginLocation) {
+    auto avatar = std::make_unique<ChatAvatar>(this, name, address, userId, loginAttributes, loginLocation);
+    avatar->avatarId_ = NextAvatarId();
+    auto* result = avatar.get();
+    avatarCache_.push_back(std::move(avatar));
+    return result;
+}
 
-void ChatAvatarService::LogoutAvatar(ChatAvatar*) {}
+void ChatAvatarService::DestroyAvatar(ChatAvatar* avatar) {
+    if (!avatar) {
+        return;
+    }
+
+    avatarCache_.erase(std::remove_if(std::begin(avatarCache_), std::end(avatarCache_),
+                               [avatar](const auto& candidate) { return candidate.get() == avatar; }),
+        std::end(avatarCache_));
+}
+
+void ChatAvatarService::LoginAvatar(ChatAvatar* avatar) {
+    if (!avatar) {
+        return;
+    }
+
+    if (!IsOnline(avatar)) {
+        onlineAvatars_.push_back(avatar);
+    }
+    avatar->isOnline_ = true;
+}
+
+void ChatAvatarService::LogoutAvatar(ChatAvatar* avatar) {
+    if (!avatar) {
+        return;
+    }
+
+    onlineAvatars_.erase(std::remove(std::begin(onlineAvatars_), std::end(onlineAvatars_), avatar),
+        std::end(onlineAvatars_));
+    avatar->isOnline_ = false;
+}
 
 void ChatAvatarService::PersistAvatar(const ChatAvatar*) {}
 
@@ -32,3 +85,6 @@ void ChatAvatarService::RemoveIgnore(uint32_t, uint32_t) {}
 
 void ChatAvatarService::UpdateFriendComment(uint32_t, uint32_t, const std::u16string&) {}
 
+bool ChatAvatarService::IsOnline(const ChatAvatar* avatar) const {
+    return std::find(std::begin(onlineAvatars_), std::end(onlineAvatars_), avatar) != std::end(onlineAvatars_);
+}

--- a/tests/stationchat/WebsiteIntegrationService_Tests.cpp
+++ b/tests/stationchat/WebsiteIntegrationService_Tests.cpp
@@ -1,0 +1,106 @@
+#include "WebsiteIntegrationService.hpp"
+
+#include "ChatAvatarService.hpp"
+#include "FakeMariaDB.hpp"
+#include "PersistentMessage.hpp"
+#include "StationChatConfig.hpp"
+#include "StringUtils.hpp"
+
+#include "catch.hpp"
+
+TEST_CASE("WebsiteIntegrationService skips work when disabled", "[stationchat]") {
+    MariaDBConnection db;
+    db.userLinkTableName = "web_user_avatar";
+    db.onlineStatusTableName = "web_avatar_status";
+    db.mailTableName = "web_persistent_message";
+
+    StationChatConfig config;
+    config.websiteIntegration.enabled = false;
+
+    WebsiteIntegrationService service{&db, config};
+    ChatAvatarService avatarService{&db};
+
+    auto* avatar = avatarService.CreateAvatar(u"Rex", u"clone", 77, 0, u"Kamino");
+
+    PersistentMessage message;
+    message.header.avatarId = avatar->GetAvatarId();
+    message.header.messageId = 12;
+    message.header.fromName = u"Anakin";
+    message.header.fromAddress = u"Coruscant";
+    message.header.subject = u"Report";
+    message.header.sentTime = 42;
+    message.header.status = PersistentState::NEW;
+    message.message = u"Stay alert.";
+
+    service.RecordAvatarLogin(*avatar);
+    service.RecordAvatarLogout(*avatar);
+    service.RecordPersistentMessage(*avatar, message);
+
+    CHECK(db.preparedSql.empty());
+    CHECK(db.websiteUserLinks.empty());
+    CHECK(db.websiteStatusRows.empty());
+    CHECK(db.websiteMailRows.empty());
+}
+
+TEST_CASE("WebsiteIntegrationService records website synchronization state", "[stationchat]") {
+    MariaDBConnection db;
+    db.userLinkTableName = "web_user_avatar";
+    db.onlineStatusTableName = "web_avatar_status";
+    db.mailTableName = "web_persistent_message";
+
+    db.columnDefinitions[db.userLinkTableName]["created_at"] = {true, false, "int"};
+    db.columnDefinitions[db.userLinkTableName]["updated_at"] = {true, false, "int"};
+    db.columnDefinitions[db.onlineStatusTableName]["created_at"] = {true, false, "int"};
+    db.columnDefinitions[db.onlineStatusTableName]["updated_at"] = {true, false, "int"};
+    db.columnDefinitions[db.onlineStatusTableName]["last_login"] = {true, false, "int"};
+    db.columnDefinitions[db.onlineStatusTableName]["last_logout"] = {true, false, "int"};
+    db.columnDefinitions[db.mailTableName]["created_at"] = {true, false, "int"};
+    db.columnDefinitions[db.mailTableName]["updated_at"] = {true, false, "int"};
+
+    StationChatConfig config;
+    config.websiteIntegration.enabled = true;
+
+    WebsiteIntegrationService service{&db, config};
+    ChatAvatarService avatarService{&db};
+
+    auto* avatar = avatarService.CreateAvatar(u"Hera", u"phoenix", 88, 0, u"Lothal");
+
+    service.RecordAvatarLogin(*avatar);
+
+    REQUIRE(db.websiteUserLinks.size() == 1);
+    const auto& userLink = db.websiteUserLinks.front();
+    CHECK(userLink.userId == avatar->GetUserId());
+    CHECK(userLink.avatarId == avatar->GetAvatarId());
+    CHECK(userLink.avatarName == FromWideString(avatar->GetName()));
+
+    REQUIRE(db.websiteStatusRows.size() == 1);
+    const auto& status = db.websiteStatusRows.front();
+    CHECK(status.isOnline == 1u);
+    CHECK(status.lastLogin != 0u);
+    CHECK(status.lastLogout == 0u);
+
+    service.RecordAvatarLogout(*avatar);
+    REQUIRE(db.websiteStatusRows.size() == 1);
+    const auto& updatedStatus = db.websiteStatusRows.front();
+    CHECK(updatedStatus.isOnline == 0u);
+    CHECK(updatedStatus.lastLogout != 0u);
+
+    PersistentMessage persisted;
+    persisted.header.avatarId = avatar->GetAvatarId();
+    persisted.header.messageId = 33;
+    persisted.header.fromName = u"Kanan";
+    persisted.header.fromAddress = u"Rebels";
+    persisted.header.subject = u"Meeting";
+    persisted.header.sentTime = 555;
+    persisted.header.status = PersistentState::UNREAD;
+    persisted.message = u"May the Force be with you";
+
+    service.RecordPersistentMessage(*avatar, persisted);
+
+    REQUIRE(db.websiteMailRows.size() == 1);
+    const auto& mail = db.websiteMailRows.front();
+    CHECK(mail.avatarId == avatar->GetAvatarId());
+    CHECK(mail.messageId == persisted.header.messageId);
+    CHECK(mail.subject == FromWideString(persisted.header.subject));
+    CHECK(mail.status == static_cast<uint32_t>(persisted.header.status));
+}


### PR DESCRIPTION
## Summary
- extend the stationchat test target with suites for ChatRoomService, PersistentMessageService, and WebsiteIntegrationService
- beef up the FakeMariaDB and stub ChatAvatarService helpers so the new tests can exercise persistence and website sync behaviour
- document how to build and run the Catch2 suites in the README

## Testing
- cmake -S . -B build *(fails: missing proprietary udplibrary in externals/)*

------
https://chatgpt.com/codex/tasks/task_e_68fb6b722fec832ca64da627356e9807