### PR TITLE
Cache website integration prepared statements and add tests

### DIFF
--- a/src/stationapi/MariaDB.cpp
+++ b/src/stationapi/MariaDB.cpp
@@ -596,6 +596,20 @@ int mariadb_step(MariaDBStatement* stmt) {
     return MARIADB_ROW;
 }
 
+int mariadb_reset(MariaDBStatement* stmt) {
+    if (!stmt) {
+        return MARIADB_OK;
+    }
+
+    ClearResult(stmt);
+    stmt->executed = false;
+    stmt->isSelect = false;
+    stmt->currentRow = nullptr;
+    stmt->currentLengths.clear();
+    stmt->connectionHandleAtExecution = nullptr;
+    return MARIADB_OK;
+}
+
 int mariadb_finalize(MariaDBStatement* stmt) {
     if (!stmt) {
         return MARIADB_OK;

--- a/src/stationapi/MariaDB.hpp
+++ b/src/stationapi/MariaDB.hpp
@@ -43,6 +43,7 @@ int mariadb_bind_text(MariaDBStatement* stmt, int index, const char* value, int 
 int mariadb_bind_blob(MariaDBStatement* stmt, int index, const void* value, int length, void (*)(void*));
 
 int mariadb_step(MariaDBStatement* stmt);
+int mariadb_reset(MariaDBStatement* stmt);
 int mariadb_finalize(MariaDBStatement* stmt);
 
 int mariadb_column_int(MariaDBStatement* stmt, int column);

--- a/src/stationchat/WebsiteIntegrationService.cpp
+++ b/src/stationchat/WebsiteIntegrationService.cpp
@@ -227,9 +227,77 @@ WebsiteIntegrationService::WebsiteIntegrationService(MariaDBConnection* db, cons
     userLinkSql_ = BuildUserLinkSql(userLinkTable_, userLinkCreatedAt_.exists, userLinkUpdatedAt_.exists);
     statusSql_ = BuildStatusSql(onlineStatusTable_, statusCreatedAt_.exists, statusUpdatedAt_.exists);
     mailSql_ = BuildMailSql(mailTable_, mailCreatedAt_.exists, mailUpdatedAt_.exists);
+
+    if (!userLinkSql_.empty()) {
+        MariaDBStatement* stmt{nullptr};
+        auto result = mariadb_prepare(db_, userLinkSql_.c_str(), -1, &stmt, 0);
+        if (result != MARIADB_OK) {
+            throw MariaDBException{result, mariadb_errmsg(db_)};
+        }
+
+        userLinkStmt_.handle = stmt;
+        userLinkStmt_.userIdIdx = mariadb_bind_parameter_index(stmt, "@user_id");
+        userLinkStmt_.avatarIdIdx = mariadb_bind_parameter_index(stmt, "@avatar_id");
+        userLinkStmt_.avatarNameIdx = mariadb_bind_parameter_index(stmt, "@avatar_name");
+        userLinkStmt_.createdAtIdx = userLinkCreatedAt_.exists ? mariadb_bind_parameter_index(stmt, "@created_at") : 0;
+        userLinkStmt_.updatedAtIdx = userLinkUpdatedAt_.exists ? mariadb_bind_parameter_index(stmt, "@updated_at") : 0;
+    }
+
+    if (!statusSql_.empty()) {
+        MariaDBStatement* stmt{nullptr};
+        auto result = mariadb_prepare(db_, statusSql_.c_str(), -1, &stmt, 0);
+        if (result != MARIADB_OK) {
+            throw MariaDBException{result, mariadb_errmsg(db_)};
+        }
+
+        statusStmt_.handle = stmt;
+        statusStmt_.avatarIdIdx = mariadb_bind_parameter_index(stmt, "@avatar_id");
+        statusStmt_.userIdIdx = mariadb_bind_parameter_index(stmt, "@user_id");
+        statusStmt_.avatarNameIdx = mariadb_bind_parameter_index(stmt, "@avatar_name");
+        statusStmt_.isOnlineIdx = mariadb_bind_parameter_index(stmt, "@is_online");
+        statusStmt_.lastLoginIdx = statusLoginAt_.exists ? mariadb_bind_parameter_index(stmt, "@last_login") : 0;
+        statusStmt_.lastLogoutIdx = statusLogoutAt_.exists ? mariadb_bind_parameter_index(stmt, "@last_logout") : 0;
+        statusStmt_.updatedAtIdx = statusUpdatedAt_.exists ? mariadb_bind_parameter_index(stmt, "@updated_at") : 0;
+        statusStmt_.createdAtIdx = statusCreatedAt_.exists ? mariadb_bind_parameter_index(stmt, "@created_at") : 0;
+    }
+
+    if (!mailSql_.empty()) {
+        MariaDBStatement* stmt{nullptr};
+        auto result = mariadb_prepare(db_, mailSql_.c_str(), -1, &stmt, 0);
+        if (result != MARIADB_OK) {
+            throw MariaDBException{result, mariadb_errmsg(db_)};
+        }
+
+        mailStmt_.handle = stmt;
+        mailStmt_.avatarIdIdx = mariadb_bind_parameter_index(stmt, "@avatar_id");
+        mailStmt_.userIdIdx = mariadb_bind_parameter_index(stmt, "@user_id");
+        mailStmt_.avatarNameIdx = mariadb_bind_parameter_index(stmt, "@avatar_name");
+        mailStmt_.messageIdIdx = mariadb_bind_parameter_index(stmt, "@message_id");
+        mailStmt_.senderNameIdx = mariadb_bind_parameter_index(stmt, "@sender_name");
+        mailStmt_.senderAddressIdx = mariadb_bind_parameter_index(stmt, "@sender_address");
+        mailStmt_.subjectIdx = mariadb_bind_parameter_index(stmt, "@subject");
+        mailStmt_.bodyIdx = mariadb_bind_parameter_index(stmt, "@body");
+        mailStmt_.oobIdx = mariadb_bind_parameter_index(stmt, "@oob");
+        mailStmt_.sentTimeIdx = mariadb_bind_parameter_index(stmt, "@sent_time");
+        mailStmt_.createdAtIdx = mailCreatedAt_.exists ? mariadb_bind_parameter_index(stmt, "@created_at") : 0;
+        mailStmt_.updatedAtIdx = mailUpdatedAt_.exists ? mariadb_bind_parameter_index(stmt, "@updated_at") : 0;
+        mailStmt_.statusIdx = mariadb_bind_parameter_index(stmt, "@status");
+    }
 }
 
 WebsiteIntegrationService::~WebsiteIntegrationService() {
+    if (mailStmt_.handle) {
+        mariadb_finalize(mailStmt_.handle);
+        mailStmt_.handle = nullptr;
+    }
+    if (statusStmt_.handle) {
+        mariadb_finalize(statusStmt_.handle);
+        statusStmt_.handle = nullptr;
+    }
+    if (userLinkStmt_.handle) {
+        mariadb_finalize(userLinkStmt_.handle);
+        userLinkStmt_.handle = nullptr;
+    }
     if (ownsDatabase_) {
         mariadb_close(db_);
         db_ = nullptr;
@@ -261,25 +329,15 @@ void WebsiteIntegrationService::RecordPersistentMessage(
 
     EnsureUserLink(destAvatar);
 
-    MariaDBStatement* stmt;
-    auto result = mariadb_prepare(db_, mailSql_.c_str(), -1, &stmt, 0);
+    auto* stmt = mailStmt_.handle;
+    if (!stmt) {
+        throw std::runtime_error("Mail statement not prepared");
+    }
+
+    auto result = mariadb_reset(stmt);
     if (result != MARIADB_OK) {
         throw MariaDBException{result, mariadb_errmsg(db_)};
     }
-
-    auto avatarIdIdx = mariadb_bind_parameter_index(stmt, "@avatar_id");
-    auto userIdIdx = mariadb_bind_parameter_index(stmt, "@user_id");
-    auto avatarNameIdx = mariadb_bind_parameter_index(stmt, "@avatar_name");
-    auto messageIdIdx = mariadb_bind_parameter_index(stmt, "@message_id");
-    auto senderNameIdx = mariadb_bind_parameter_index(stmt, "@sender_name");
-    auto senderAddressIdx = mariadb_bind_parameter_index(stmt, "@sender_address");
-    auto subjectIdx = mariadb_bind_parameter_index(stmt, "@subject");
-    auto bodyIdx = mariadb_bind_parameter_index(stmt, "@body");
-    auto oobIdx = mariadb_bind_parameter_index(stmt, "@oob");
-    auto sentTimeIdx = mariadb_bind_parameter_index(stmt, "@sent_time");
-    auto createdAtIdx = mailCreatedAt_.exists ? mariadb_bind_parameter_index(stmt, "@created_at") : -1;
-    auto updatedAtIdx = mailUpdatedAt_.exists ? mariadb_bind_parameter_index(stmt, "@updated_at") : -1;
-    auto statusIdx = mariadb_bind_parameter_index(stmt, "@status");
 
     std::vector<std::string> ownedStrings;
 
@@ -291,27 +349,46 @@ void WebsiteIntegrationService::RecordPersistentMessage(
     auto oob = FromWideString(message.oob);
     auto now = CurrentUnixTime();
 
-    mariadb_bind_int(stmt, avatarIdIdx, destAvatar.GetAvatarId());
-    mariadb_bind_int(stmt, userIdIdx, destAvatar.GetUserId());
-    mariadb_bind_text(stmt, avatarNameIdx, avatarName.c_str(), -1, 0);
-    mariadb_bind_int(stmt, messageIdIdx, message.header.messageId);
-    mariadb_bind_text(stmt, senderNameIdx, senderName.c_str(), -1, 0);
-    mariadb_bind_text(stmt, senderAddressIdx, senderAddress.c_str(), -1, 0);
-    mariadb_bind_text(stmt, subjectIdx, subject.c_str(), -1, 0);
-    mariadb_bind_text(stmt, bodyIdx, body.c_str(), -1, 0);
-    mariadb_bind_text(stmt, oobIdx, oob.c_str(), -1, 0);
-    mariadb_bind_int(stmt, sentTimeIdx, message.header.sentTime);
-    BindTimestampParameter(stmt, createdAtIdx, mailCreatedAt_, now, ownedStrings);
-    BindTimestampParameter(stmt, updatedAtIdx, mailUpdatedAt_, now, ownedStrings);
-    mariadb_bind_int(stmt, statusIdx, static_cast<uint32_t>(message.header.status));
+    if (mailStmt_.avatarIdIdx > 0) {
+        mariadb_bind_int(stmt, mailStmt_.avatarIdIdx, destAvatar.GetAvatarId());
+    }
+    if (mailStmt_.userIdIdx > 0) {
+        mariadb_bind_int(stmt, mailStmt_.userIdIdx, destAvatar.GetUserId());
+    }
+    if (mailStmt_.avatarNameIdx > 0) {
+        mariadb_bind_text(stmt, mailStmt_.avatarNameIdx, avatarName.c_str(), -1, 0);
+    }
+    if (mailStmt_.messageIdIdx > 0) {
+        mariadb_bind_int(stmt, mailStmt_.messageIdIdx, message.header.messageId);
+    }
+    if (mailStmt_.senderNameIdx > 0) {
+        mariadb_bind_text(stmt, mailStmt_.senderNameIdx, senderName.c_str(), -1, 0);
+    }
+    if (mailStmt_.senderAddressIdx > 0) {
+        mariadb_bind_text(stmt, mailStmt_.senderAddressIdx, senderAddress.c_str(), -1, 0);
+    }
+    if (mailStmt_.subjectIdx > 0) {
+        mariadb_bind_text(stmt, mailStmt_.subjectIdx, subject.c_str(), -1, 0);
+    }
+    if (mailStmt_.bodyIdx > 0) {
+        mariadb_bind_text(stmt, mailStmt_.bodyIdx, body.c_str(), -1, 0);
+    }
+    if (mailStmt_.oobIdx > 0) {
+        mariadb_bind_text(stmt, mailStmt_.oobIdx, oob.c_str(), -1, 0);
+    }
+    if (mailStmt_.sentTimeIdx > 0) {
+        mariadb_bind_int(stmt, mailStmt_.sentTimeIdx, message.header.sentTime);
+    }
+    BindTimestampParameter(stmt, mailStmt_.createdAtIdx, mailCreatedAt_, now, ownedStrings);
+    BindTimestampParameter(stmt, mailStmt_.updatedAtIdx, mailUpdatedAt_, now, ownedStrings);
+    if (mailStmt_.statusIdx > 0) {
+        mariadb_bind_int(stmt, mailStmt_.statusIdx, static_cast<uint32_t>(message.header.status));
+    }
 
     result = mariadb_step(stmt);
     if (result != MARIADB_DONE) {
-        mariadb_finalize(stmt);
         throw MariaDBException{result, mariadb_errmsg(db_)};
     }
-
-    mariadb_finalize(stmt);
 }
 
 void WebsiteIntegrationService::EnsureUserLink(const ChatAvatar& avatar) {
@@ -323,36 +400,37 @@ void WebsiteIntegrationService::EnsureUserLink(const ChatAvatar& avatar) {
         return;
     }
 
-    MariaDBStatement* stmt;
-    auto result = mariadb_prepare(db_, userLinkSql_.c_str(), -1, &stmt, 0);
+    auto* stmt = userLinkStmt_.handle;
+    if (!stmt) {
+        throw std::runtime_error("User link statement not prepared");
+    }
+
+    auto result = mariadb_reset(stmt);
     if (result != MARIADB_OK) {
         throw MariaDBException{result, mariadb_errmsg(db_)};
     }
-
-    auto userIdIdx = mariadb_bind_parameter_index(stmt, "@user_id");
-    auto avatarIdIdx = mariadb_bind_parameter_index(stmt, "@avatar_id");
-    auto avatarNameIdx = mariadb_bind_parameter_index(stmt, "@avatar_name");
-    auto createdAtIdx = userLinkCreatedAt_.exists ? mariadb_bind_parameter_index(stmt, "@created_at") : -1;
-    auto updatedAtIdx = userLinkUpdatedAt_.exists ? mariadb_bind_parameter_index(stmt, "@updated_at") : -1;
 
     std::vector<std::string> ownedStrings;
 
     auto avatarName = FromWideString(avatar.GetName());
     auto now = CurrentUnixTime();
 
-    mariadb_bind_int(stmt, userIdIdx, avatar.GetUserId());
-    mariadb_bind_int(stmt, avatarIdIdx, avatar.GetAvatarId());
-    mariadb_bind_text(stmt, avatarNameIdx, avatarName.c_str(), -1, 0);
-    BindTimestampParameter(stmt, createdAtIdx, userLinkCreatedAt_, now, ownedStrings);
-    BindTimestampParameter(stmt, updatedAtIdx, userLinkUpdatedAt_, now, ownedStrings);
+    if (userLinkStmt_.userIdIdx > 0) {
+        mariadb_bind_int(stmt, userLinkStmt_.userIdIdx, avatar.GetUserId());
+    }
+    if (userLinkStmt_.avatarIdIdx > 0) {
+        mariadb_bind_int(stmt, userLinkStmt_.avatarIdIdx, avatar.GetAvatarId());
+    }
+    if (userLinkStmt_.avatarNameIdx > 0) {
+        mariadb_bind_text(stmt, userLinkStmt_.avatarNameIdx, avatarName.c_str(), -1, 0);
+    }
+    BindTimestampParameter(stmt, userLinkStmt_.createdAtIdx, userLinkCreatedAt_, now, ownedStrings);
+    BindTimestampParameter(stmt, userLinkStmt_.updatedAtIdx, userLinkUpdatedAt_, now, ownedStrings);
 
     result = mariadb_step(stmt);
     if (result != MARIADB_DONE) {
-        mariadb_finalize(stmt);
         throw MariaDBException{result, mariadb_errmsg(db_)};
     }
-
-    mariadb_finalize(stmt);
 }
 
 void WebsiteIntegrationService::UpdateOnlineStatus(const ChatAvatar& avatar, bool isOnline) {
@@ -360,20 +438,15 @@ void WebsiteIntegrationService::UpdateOnlineStatus(const ChatAvatar& avatar, boo
         return;
     }
 
-    MariaDBStatement* stmt;
-    auto result = mariadb_prepare(db_, statusSql_.c_str(), -1, &stmt, 0);
+    auto* stmt = statusStmt_.handle;
+    if (!stmt) {
+        throw std::runtime_error("Status statement not prepared");
+    }
+
+    auto result = mariadb_reset(stmt);
     if (result != MARIADB_OK) {
         throw MariaDBException{result, mariadb_errmsg(db_)};
     }
-
-    auto avatarIdIdx = mariadb_bind_parameter_index(stmt, "@avatar_id");
-    auto userIdIdx = mariadb_bind_parameter_index(stmt, "@user_id");
-    auto avatarNameIdx = mariadb_bind_parameter_index(stmt, "@avatar_name");
-    auto onlineIdx = mariadb_bind_parameter_index(stmt, "@is_online");
-    auto loginIdx = mariadb_bind_parameter_index(stmt, "@last_login");
-    auto logoutIdx = mariadb_bind_parameter_index(stmt, "@last_logout");
-    auto updatedIdx = statusUpdatedAt_.exists ? mariadb_bind_parameter_index(stmt, "@updated_at") : -1;
-    auto createdIdx = statusCreatedAt_.exists ? mariadb_bind_parameter_index(stmt, "@created_at") : -1;
 
     std::vector<std::string> ownedStrings;
 
@@ -383,22 +456,27 @@ void WebsiteIntegrationService::UpdateOnlineStatus(const ChatAvatar& avatar, boo
     auto loginTime = isOnline ? now : 0u;
     auto logoutTime = isOnline ? 0u : now;
 
-    mariadb_bind_int(stmt, avatarIdIdx, avatar.GetAvatarId());
-    mariadb_bind_int(stmt, userIdIdx, avatar.GetUserId());
-    mariadb_bind_text(stmt, avatarNameIdx, avatarName.c_str(), -1, 0);
-    mariadb_bind_int(stmt, onlineIdx, static_cast<uint32_t>(isOnline ? 1 : 0));
-    BindTimestampParameter(stmt, loginIdx, statusLoginAt_, loginTime, ownedStrings);
-    BindTimestampParameter(stmt, logoutIdx, statusLogoutAt_, logoutTime, ownedStrings);
-    BindTimestampParameter(stmt, updatedIdx, statusUpdatedAt_, now, ownedStrings);
-    BindTimestampParameter(stmt, createdIdx, statusCreatedAt_, now, ownedStrings);
+    if (statusStmt_.avatarIdIdx > 0) {
+        mariadb_bind_int(stmt, statusStmt_.avatarIdIdx, avatar.GetAvatarId());
+    }
+    if (statusStmt_.userIdIdx > 0) {
+        mariadb_bind_int(stmt, statusStmt_.userIdIdx, avatar.GetUserId());
+    }
+    if (statusStmt_.avatarNameIdx > 0) {
+        mariadb_bind_text(stmt, statusStmt_.avatarNameIdx, avatarName.c_str(), -1, 0);
+    }
+    if (statusStmt_.isOnlineIdx > 0) {
+        mariadb_bind_int(stmt, statusStmt_.isOnlineIdx, static_cast<uint32_t>(isOnline ? 1 : 0));
+    }
+    BindTimestampParameter(stmt, statusStmt_.lastLoginIdx, statusLoginAt_, loginTime, ownedStrings);
+    BindTimestampParameter(stmt, statusStmt_.lastLogoutIdx, statusLogoutAt_, logoutTime, ownedStrings);
+    BindTimestampParameter(stmt, statusStmt_.updatedAtIdx, statusUpdatedAt_, now, ownedStrings);
+    BindTimestampParameter(stmt, statusStmt_.createdAtIdx, statusCreatedAt_, now, ownedStrings);
 
     result = mariadb_step(stmt);
     if (result != MARIADB_DONE) {
-        mariadb_finalize(stmt);
         throw MariaDBException{result, mariadb_errmsg(db_)};
     }
-
-    mariadb_finalize(stmt);
 }
 
 WebsiteIntegrationService::ColumnInfo WebsiteIntegrationService::InspectColumn(

--- a/src/stationchat/WebsiteIntegrationService.hpp
+++ b/src/stationchat/WebsiteIntegrationService.hpp
@@ -27,6 +27,44 @@ private:
         bool isDateTime{false};
     };
 
+    struct PreparedUserLinkStatement {
+        MariaDBStatement* handle{nullptr};
+        int userIdIdx{0};
+        int avatarIdIdx{0};
+        int avatarNameIdx{0};
+        int createdAtIdx{0};
+        int updatedAtIdx{0};
+    };
+
+    struct PreparedStatusStatement {
+        MariaDBStatement* handle{nullptr};
+        int avatarIdIdx{0};
+        int userIdIdx{0};
+        int avatarNameIdx{0};
+        int isOnlineIdx{0};
+        int lastLoginIdx{0};
+        int lastLogoutIdx{0};
+        int updatedAtIdx{0};
+        int createdAtIdx{0};
+    };
+
+    struct PreparedMailStatement {
+        MariaDBStatement* handle{nullptr};
+        int avatarIdIdx{0};
+        int userIdIdx{0};
+        int avatarNameIdx{0};
+        int messageIdIdx{0};
+        int senderNameIdx{0};
+        int senderAddressIdx{0};
+        int subjectIdx{0};
+        int bodyIdx{0};
+        int oobIdx{0};
+        int sentTimeIdx{0};
+        int createdAtIdx{0};
+        int updatedAtIdx{0};
+        int statusIdx{0};
+    };
+
     void EnsureUserLink(const ChatAvatar& avatar);
     void UpdateOnlineStatus(const ChatAvatar& avatar, bool isOnline);
     ColumnInfo InspectColumn(const std::string& table, const std::string& column);
@@ -52,4 +90,7 @@ private:
     ColumnInfo statusLogoutAt_;
     ColumnInfo mailCreatedAt_;
     ColumnInfo mailUpdatedAt_;
+    PreparedUserLinkStatement userLinkStmt_;
+    PreparedStatusStatement statusStmt_;
+    PreparedMailStatement mailStmt_;
 };

--- a/tests/stationchat/FakeMariaDB.cpp
+++ b/tests/stationchat/FakeMariaDB.cpp
@@ -1,19 +1,305 @@
 #include "FakeMariaDB.hpp"
 
 #include <algorithm>
+#include <cctype>
 #include <cstdint>
 #include <cstring>
 #include <optional>
+#include <unordered_map>
+#include <utility>
+
+namespace {
+
+enum class StatementType {
+    Unknown,
+    RoomSelect,
+    ShowColumns,
+    UserLinkUpsert,
+    StatusUpsert,
+    MailUpsert,
+};
+
+struct BoundParameter {
+    enum class Kind {
+        None,
+        Int,
+        Text,
+        Blob,
+    };
+
+    Kind kind{Kind::None};
+    bool isNull{true};
+    int intValue{0};
+    std::string textValue;
+
+    void Reset() {
+        kind = Kind::None;
+        isNull = true;
+        intValue = 0;
+        textValue.clear();
+    }
+};
 
 struct MariaDBStatement {
     MariaDBConnection* connection{nullptr};
     std::string sql;
-    std::optional<std::string> baseAddress;
+    StatementType type{StatementType::Unknown};
+    std::string tableName;
+    std::vector<std::string> parameterNames;
+    std::unordered_map<std::string, int> parameterIndex;
+    std::vector<BoundParameter> bindings;
+
+    // Result set state for room selection
     std::vector<const FakeRoomRow*> matchedRows;
     std::size_t currentIndex{0};
     const FakeRoomRow* currentRow{nullptr};
-    bool prepared{false};
+
+    // Result set state for SHOW COLUMNS
+    bool showColumnHasRow{false};
+    bool showColumnReturned{false};
+    std::string showColumnType;
+
+    bool executed{false};
 };
+
+std::string Trim(const std::string& value) {
+    auto begin = value.find_first_not_of(" \t\n\r");
+    if (begin == std::string::npos) {
+        return "";
+    }
+    auto end = value.find_last_not_of(" \t\n\r");
+    return value.substr(begin, end - begin + 1);
+}
+
+std::string StripBackticks(const std::string& identifier) {
+    std::string out;
+    out.reserve(identifier.size());
+    for (char ch : identifier) {
+        if (ch != '`') {
+            out.push_back(ch);
+        }
+    }
+    return out;
+}
+
+std::string ExtractTableName(const std::string& sql, const std::string& prefix, const std::string& terminator) {
+    auto prefixPos = sql.find(prefix);
+    if (prefixPos == std::string::npos) {
+        return {};
+    }
+
+    prefixPos += prefix.size();
+    auto begin = sql.find_first_not_of(" \t", prefixPos);
+    if (begin == std::string::npos) {
+        return {};
+    }
+
+    std::size_t end = std::string::npos;
+    if (!terminator.empty()) {
+        end = sql.find(terminator, begin);
+    }
+    if (end == std::string::npos) {
+        end = sql.find_first_of(" \t(\n\r", begin);
+        if (end == std::string::npos) {
+            end = sql.size();
+        }
+    }
+
+    auto raw = sql.substr(begin, end - begin);
+    return StripBackticks(Trim(raw));
+}
+
+void ParseParameterNames(MariaDBStatement* stmt) {
+    if (!stmt) {
+        return;
+    }
+
+    const auto& sql = stmt->sql;
+    std::size_t i = 0;
+    while (i < sql.size()) {
+        if (sql[i] != '@') {
+            ++i;
+            continue;
+        }
+
+        std::size_t j = i + 1;
+        std::string name;
+        while (j < sql.size()) {
+            char ch = sql[j];
+            if (std::isalnum(static_cast<unsigned char>(ch)) || ch == '_') {
+                name.push_back(ch);
+                ++j;
+            } else {
+                break;
+            }
+        }
+
+        if (!name.empty()) {
+            if (!stmt->parameterIndex.count(name)) {
+                int index = static_cast<int>(stmt->parameterNames.size() + 1);
+                stmt->parameterNames.push_back(name);
+                stmt->parameterIndex.emplace(name, index);
+            }
+            i = j;
+        } else {
+            ++i;
+        }
+    }
+
+    stmt->bindings.resize(stmt->parameterNames.size());
+}
+
+void DetermineStatementType(MariaDBStatement* stmt) {
+    if (!stmt || !stmt->connection) {
+        return;
+    }
+
+    const auto& sql = stmt->sql;
+    if (sql.find("SHOW COLUMNS FROM") != std::string::npos) {
+        stmt->type = StatementType::ShowColumns;
+        stmt->tableName = ExtractTableName(sql, "SHOW COLUMNS FROM", "LIKE");
+        return;
+    }
+
+    if (sql.find("SELECT") != std::string::npos && sql.find("room_address") != std::string::npos) {
+        stmt->type = StatementType::RoomSelect;
+        return;
+    }
+
+    if (sql.find("INSERT INTO") != std::string::npos) {
+        stmt->tableName = ExtractTableName(sql, "INSERT INTO", "");
+        const auto& connection = *stmt->connection;
+        if (stmt->tableName == connection.userLinkTableName) {
+            stmt->type = StatementType::UserLinkUpsert;
+        } else if (stmt->tableName == connection.statusTableName) {
+            stmt->type = StatementType::StatusUpsert;
+        } else if (stmt->tableName == connection.mailTableName) {
+            stmt->type = StatementType::MailUpsert;
+        }
+        return;
+    }
+
+    stmt->type = StatementType::Unknown;
+}
+
+const BoundParameter* GetBinding(const MariaDBStatement* stmt, const std::string& name) {
+    if (!stmt) {
+        return nullptr;
+    }
+    auto it = stmt->parameterIndex.find(name);
+    if (it == stmt->parameterIndex.end()) {
+        return nullptr;
+    }
+    int index = it->second;
+    if (index <= 0 || static_cast<std::size_t>(index) > stmt->bindings.size()) {
+        return nullptr;
+    }
+    return &stmt->bindings[static_cast<std::size_t>(index - 1)];
+}
+
+std::optional<int> GetIntParameter(const MariaDBStatement* stmt, const std::string& name) {
+    const auto* binding = GetBinding(stmt, name);
+    if (!binding || binding->isNull) {
+        return std::nullopt;
+    }
+    if (binding->kind == BoundParameter::Kind::Int) {
+        return binding->intValue;
+    }
+    if (binding->kind == BoundParameter::Kind::Text) {
+        try {
+            return std::stoi(binding->textValue);
+        } catch (...) {
+            return std::nullopt;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string> GetTextParameter(const MariaDBStatement* stmt, const std::string& name) {
+    const auto* binding = GetBinding(stmt, name);
+    if (!binding || binding->isNull) {
+        return std::nullopt;
+    }
+    if (binding->kind == BoundParameter::Kind::Text) {
+        return binding->textValue;
+    }
+    if (binding->kind == BoundParameter::Kind::Int) {
+        return std::to_string(binding->intValue);
+    }
+    return std::nullopt;
+}
+
+const FakeColumnDefinition* FindColumnDefinition(const MariaDBConnection* connection,
+    const std::string& tableName, const std::string& columnName) {
+    if (!connection) {
+        return nullptr;
+    }
+    auto tableIt = connection->tableColumns.find(tableName);
+    if (tableIt == connection->tableColumns.end()) {
+        return nullptr;
+    }
+    auto columnIt = tableIt->second.find(columnName);
+    if (columnIt == tableIt->second.end()) {
+        return nullptr;
+    }
+    return &columnIt->second;
+}
+
+FakeTimestampValue BuildTimestampValue(const MariaDBStatement* stmt, const std::string& parameterName,
+    const std::string& columnName) {
+    FakeTimestampValue value;
+    value.isNull = true;
+
+    if (!stmt) {
+        return value;
+    }
+
+    auto def = FindColumnDefinition(stmt->connection, stmt->tableName, columnName);
+    if (def) {
+        value.isDateTime = def->isDateTime;
+    }
+
+    const auto* binding = GetBinding(stmt, parameterName);
+    if (!binding || binding->kind == BoundParameter::Kind::None) {
+        return value;
+    }
+
+    if (binding->isNull) {
+        return value;
+    }
+
+    switch (binding->kind) {
+    case BoundParameter::Kind::Int:
+        value.isNull = false;
+        value.intValue = static_cast<uint32_t>(binding->intValue);
+        value.textValue = std::to_string(binding->intValue);
+        break;
+    case BoundParameter::Kind::Text:
+        value.isNull = false;
+        value.textValue = binding->textValue;
+        break;
+    default:
+        break;
+    }
+
+    return value;
+}
+
+void AssignTimestamp(FakeTimestampValue& target, const FakeTimestampValue& source) {
+    target = source;
+}
+
+void AssignTimestampIfProvided(FakeTimestampValue& target, const FakeTimestampValue& source) {
+    if (source.isNull) {
+        return;
+    }
+    if (!source.isDateTime && source.intValue == 0) {
+        return;
+    }
+    AssignTimestamp(target, source);
+}
+
+} // namespace
 
 int mariadb_open(const char*, MariaDBConnection** db) {
     if (!db) {
@@ -47,46 +333,70 @@ int mariadb_prepare(MariaDBConnection* db, const char* sql, int, MariaDBStatemen
     db->lastPreparedSql = sql;
     db->lastError = "OK";
 
+    ParseParameterNames(statement);
+    DetermineStatementType(statement);
+
     *stmt = statement;
     return MARIADB_OK;
 }
 
-int mariadb_bind_parameter_index(MariaDBStatement*, const char* parameterName) {
-    if (!parameterName) {
+int mariadb_bind_parameter_index(MariaDBStatement* stmt, const char* parameterName) {
+    if (!stmt || !parameterName) {
         return 0;
     }
 
-    std::string name{parameterName};
-    if (!name.empty() && name.front() == '@') {
-        name.erase(name.begin());
+    std::string key{parameterName};
+    if (!key.empty() && key.front() == '@') {
+        key.erase(key.begin());
     }
 
-    if (name == "baseAddress") {
-        return 1;
+    auto it = stmt->parameterIndex.find(key);
+    if (it == stmt->parameterIndex.end()) {
+        return 0;
     }
-
-    return 0;
+    return it->second;
 }
 
-int mariadb_bind_int(MariaDBStatement*, int, int) {
+int mariadb_bind_int(MariaDBStatement* stmt, int index, int value) {
+    if (!stmt || index <= 0) {
+        return MARIADB_ERROR;
+    }
+
+    if (static_cast<std::size_t>(index) > stmt->bindings.size()) {
+        stmt->bindings.resize(static_cast<std::size_t>(index));
+    }
+
+    auto& binding = stmt->bindings[static_cast<std::size_t>(index - 1)];
+    binding.kind = BoundParameter::Kind::Int;
+    binding.isNull = false;
+    binding.intValue = value;
+    binding.textValue.clear();
     return MARIADB_OK;
 }
 
 int mariadb_bind_text(MariaDBStatement* stmt, int index, const char* value, int length, void (*)(void*)) {
-    if (!stmt || index != 1) {
+    if (!stmt || index <= 0) {
         return MARIADB_ERROR;
     }
 
+    if (static_cast<std::size_t>(index) > stmt->bindings.size()) {
+        stmt->bindings.resize(static_cast<std::size_t>(index));
+    }
+
+    auto& binding = stmt->bindings[static_cast<std::size_t>(index - 1)];
+    binding.kind = BoundParameter::Kind::Text;
+
     if (!value) {
-        stmt->baseAddress.reset();
+        binding.isNull = true;
+        binding.textValue.clear();
         return MARIADB_OK;
     }
 
+    binding.isNull = false;
     if (length < 0) {
         length = static_cast<int>(std::strlen(value));
     }
-
-    stmt->baseAddress = std::string(value, static_cast<std::size_t>(length));
+    binding.textValue.assign(value, static_cast<std::size_t>(length));
     return MARIADB_OK;
 }
 
@@ -99,33 +409,239 @@ int mariadb_step(MariaDBStatement* stmt) {
         return MARIADB_ERROR;
     }
 
-    if (!stmt->prepared) {
-        stmt->prepared = true;
-        stmt->currentIndex = 0;
-        stmt->matchedRows.clear();
+    auto& connection = *stmt->connection;
 
-        if (!stmt->baseAddress.has_value()) {
-            stmt->connection->lastError = "baseAddress not bound";
-            return MARIADB_ERROR;
-        }
+    switch (stmt->type) {
+    case StatementType::RoomSelect: {
+        if (!stmt->executed) {
+            stmt->executed = true;
+            stmt->currentIndex = 0;
+            stmt->matchedRows.clear();
 
-        const std::string& prefix = *stmt->baseAddress;
-        for (const auto& row : stmt->connection->roomRows) {
-            if (row.roomAddress.rfind(prefix, 0) == 0) {
-                stmt->matchedRows.push_back(&row);
+            auto baseAddress = GetTextParameter(stmt, "baseAddress");
+            if (!baseAddress) {
+                connection.lastError = "baseAddress not bound";
+                return MARIADB_ERROR;
+            }
+
+            for (const auto& row : connection.roomRows) {
+                if (row.roomAddress.rfind(*baseAddress, 0) == 0) {
+                    stmt->matchedRows.push_back(&row);
+                }
             }
         }
+
+        if (stmt->currentIndex >= stmt->matchedRows.size()) {
+            stmt->currentRow = nullptr;
+            connection.lastError = "OK";
+            return MARIADB_DONE;
+        }
+
+        stmt->currentRow = stmt->matchedRows[stmt->currentIndex++];
+        connection.lastError = "OK";
+        return MARIADB_ROW;
     }
 
-    if (stmt->currentIndex >= stmt->matchedRows.size()) {
-        stmt->currentRow = nullptr;
-        stmt->connection->lastError = "OK";
+    case StatementType::ShowColumns: {
+        if (!stmt->executed) {
+            stmt->executed = true;
+            stmt->showColumnReturned = false;
+            stmt->showColumnHasRow = false;
+
+            auto columnName = GetTextParameter(stmt, "column_name");
+            if (columnName) {
+                auto def = FindColumnDefinition(&connection, stmt->tableName, *columnName);
+                if (def) {
+                    stmt->showColumnHasRow = true;
+                    stmt->showColumnType = def->typeName;
+                }
+            }
+        }
+
+        if (!stmt->showColumnHasRow || stmt->showColumnReturned) {
+            connection.lastError = "OK";
+            return MARIADB_DONE;
+        }
+
+        stmt->showColumnReturned = true;
+        connection.lastError = "OK";
+        return MARIADB_ROW;
+    }
+
+    case StatementType::UserLinkUpsert: {
+        if (stmt->executed) {
+            connection.lastError = "OK";
+            return MARIADB_DONE;
+        }
+
+        stmt->executed = true;
+
+        auto userId = GetIntParameter(stmt, "user_id").value_or(0);
+        auto avatarId = GetIntParameter(stmt, "avatar_id").value_or(0);
+        auto avatarName = GetTextParameter(stmt, "avatar_name").value_or("");
+        auto createdAt = BuildTimestampValue(stmt, "created_at", "created_at");
+        auto updatedAt = BuildTimestampValue(stmt, "updated_at", "updated_at");
+
+        auto& rows = connection.userLinkRows[stmt->tableName];
+        auto existing = std::find_if(rows.begin(), rows.end(), [avatarId](const FakeUserLinkRow& row) {
+            return row.avatarId == avatarId;
+        });
+
+        if (existing == rows.end()) {
+            FakeUserLinkRow row;
+            row.userId = static_cast<uint32_t>(userId);
+            row.avatarId = static_cast<uint32_t>(avatarId);
+            row.avatarName = std::move(avatarName);
+            row.createdAt = createdAt;
+            row.updatedAt = updatedAt;
+            rows.push_back(std::move(row));
+        } else {
+            existing->userId = static_cast<uint32_t>(userId);
+            existing->avatarName = std::move(avatarName);
+            if (!createdAt.isNull && existing->createdAt.isNull) {
+                existing->createdAt = createdAt;
+            }
+            existing->updatedAt = updatedAt;
+        }
+
+        connection.lastError = "OK";
         return MARIADB_DONE;
     }
 
-    stmt->currentRow = stmt->matchedRows[stmt->currentIndex++];
-    stmt->connection->lastError = "OK";
-    return MARIADB_ROW;
+    case StatementType::StatusUpsert: {
+        if (stmt->executed) {
+            connection.lastError = "OK";
+            return MARIADB_DONE;
+        }
+
+        stmt->executed = true;
+
+        auto avatarId = GetIntParameter(stmt, "avatar_id").value_or(0);
+        auto userId = GetIntParameter(stmt, "user_id").value_or(0);
+        auto avatarName = GetTextParameter(stmt, "avatar_name").value_or("");
+        auto isOnline = GetIntParameter(stmt, "is_online").value_or(0) != 0;
+        auto lastLogin = BuildTimestampValue(stmt, "last_login", "last_login");
+        auto lastLogout = BuildTimestampValue(stmt, "last_logout", "last_logout");
+        auto updatedAt = BuildTimestampValue(stmt, "updated_at", "updated_at");
+        auto createdAt = BuildTimestampValue(stmt, "created_at", "created_at");
+
+        auto& rows = connection.statusRows[stmt->tableName];
+        auto existing = std::find_if(rows.begin(), rows.end(), [avatarId](const FakeStatusRow& row) {
+            return row.avatarId == static_cast<uint32_t>(avatarId);
+        });
+
+        if (existing == rows.end()) {
+            FakeStatusRow row;
+            row.avatarId = static_cast<uint32_t>(avatarId);
+            row.userId = static_cast<uint32_t>(userId);
+            row.avatarName = std::move(avatarName);
+            row.isOnline = isOnline;
+            row.lastLogin = lastLogin;
+            row.lastLogout = lastLogout;
+            row.updatedAt = updatedAt;
+            row.createdAt = createdAt;
+            rows.push_back(std::move(row));
+        } else {
+            existing->userId = static_cast<uint32_t>(userId);
+            existing->avatarName = std::move(avatarName);
+            existing->isOnline = isOnline;
+            AssignTimestampIfProvided(existing->lastLogin, lastLogin);
+            AssignTimestampIfProvided(existing->lastLogout, lastLogout);
+            existing->updatedAt = updatedAt;
+            if (!createdAt.isNull && existing->createdAt.isNull) {
+                existing->createdAt = createdAt;
+            }
+        }
+
+        connection.lastError = "OK";
+        return MARIADB_DONE;
+    }
+
+    case StatementType::MailUpsert: {
+        if (stmt->executed) {
+            connection.lastError = "OK";
+            return MARIADB_DONE;
+        }
+
+        stmt->executed = true;
+
+        auto avatarId = GetIntParameter(stmt, "avatar_id").value_or(0);
+        auto userId = GetIntParameter(stmt, "user_id").value_or(0);
+        auto avatarName = GetTextParameter(stmt, "avatar_name").value_or("");
+        auto messageId = GetIntParameter(stmt, "message_id").value_or(0);
+        auto senderName = GetTextParameter(stmt, "sender_name").value_or("");
+        auto senderAddress = GetTextParameter(stmt, "sender_address").value_or("");
+        auto subject = GetTextParameter(stmt, "subject").value_or("");
+        auto body = GetTextParameter(stmt, "body").value_or("");
+        auto oob = GetTextParameter(stmt, "oob").value_or("");
+        auto sentTime = GetIntParameter(stmt, "sent_time").value_or(0);
+        auto createdAt = BuildTimestampValue(stmt, "created_at", "created_at");
+        auto updatedAt = BuildTimestampValue(stmt, "updated_at", "updated_at");
+        auto status = GetIntParameter(stmt, "status").value_or(0);
+
+        auto& rows = connection.mailRows[stmt->tableName];
+        auto existing = std::find_if(rows.begin(), rows.end(), [messageId](const FakeMailRow& row) {
+            return row.messageId == static_cast<uint32_t>(messageId);
+        });
+
+        if (existing == rows.end()) {
+            FakeMailRow row;
+            row.avatarId = static_cast<uint32_t>(avatarId);
+            row.userId = static_cast<uint32_t>(userId);
+            row.avatarName = std::move(avatarName);
+            row.messageId = static_cast<uint32_t>(messageId);
+            row.senderName = std::move(senderName);
+            row.senderAddress = std::move(senderAddress);
+            row.subject = std::move(subject);
+            row.body = std::move(body);
+            row.oob = std::move(oob);
+            row.sentTime = static_cast<uint32_t>(sentTime);
+            row.createdAt = createdAt;
+            row.updatedAt = updatedAt;
+            row.status = static_cast<uint32_t>(status);
+            rows.push_back(std::move(row));
+        } else {
+            existing->avatarId = static_cast<uint32_t>(avatarId);
+            existing->userId = static_cast<uint32_t>(userId);
+            existing->avatarName = std::move(avatarName);
+            existing->senderName = std::move(senderName);
+            existing->senderAddress = std::move(senderAddress);
+            existing->subject = std::move(subject);
+            existing->body = std::move(body);
+            existing->oob = std::move(oob);
+            existing->sentTime = static_cast<uint32_t>(sentTime);
+            existing->createdAt = createdAt;
+            existing->updatedAt = updatedAt;
+            existing->status = static_cast<uint32_t>(status);
+        }
+
+        connection.lastError = "OK";
+        return MARIADB_DONE;
+    }
+
+    case StatementType::Unknown:
+    default:
+        connection.lastError = "Unsupported statement";
+        return MARIADB_ERROR;
+    }
+}
+
+int mariadb_reset(MariaDBStatement* stmt) {
+    if (!stmt) {
+        return MARIADB_OK;
+    }
+
+    stmt->executed = false;
+    stmt->currentIndex = 0;
+    stmt->currentRow = nullptr;
+    stmt->matchedRows.clear();
+    stmt->showColumnHasRow = false;
+    stmt->showColumnReturned = false;
+    stmt->showColumnType.clear();
+    for (auto& binding : stmt->bindings) {
+        binding.Reset();
+    }
+    return MARIADB_OK;
 }
 
 int mariadb_finalize(MariaDBStatement* stmt) {
@@ -135,6 +651,10 @@ int mariadb_finalize(MariaDBStatement* stmt) {
 
 int mariadb_column_int(MariaDBStatement* stmt, int column) {
     if (!stmt || !stmt->currentRow) {
+        return 0;
+    }
+
+    if (stmt->type != StatementType::RoomSelect) {
         return 0;
     }
 
@@ -159,12 +679,22 @@ int mariadb_column_int(MariaDBStatement* stmt, int column) {
 }
 
 const unsigned char* mariadb_column_text(MariaDBStatement* stmt, int column) {
-    if (!stmt || !stmt->currentRow) {
+    if (!stmt) {
+        return nullptr;
+    }
+
+    if (stmt->type == StatementType::ShowColumns) {
+        if (column == 1 && stmt->showColumnHasRow && stmt->showColumnReturned) {
+            return reinterpret_cast<const unsigned char*>(stmt->showColumnType.c_str());
+        }
+        return nullptr;
+    }
+
+    if (!stmt->currentRow || stmt->type != StatementType::RoomSelect) {
         return nullptr;
     }
 
     const std::string* value = nullptr;
-
     switch (column) {
     case 2:
         value = &stmt->currentRow->creatorName;
@@ -197,42 +727,27 @@ const unsigned char* mariadb_column_text(MariaDBStatement* stmt, int column) {
 const void* mariadb_column_blob(MariaDBStatement*, int) { return nullptr; }
 
 int mariadb_column_bytes(MariaDBStatement* stmt, int column) {
-    if (!stmt || !stmt->currentRow) {
+    if (!stmt) {
         return 0;
     }
 
-    const std::string* value = nullptr;
-
-    switch (column) {
-    case 2:
-        value = &stmt->currentRow->creatorName;
-        break;
-    case 3:
-        value = &stmt->currentRow->creatorAddress;
-        break;
-    case 4:
-        value = &stmt->currentRow->roomName;
-        break;
-    case 5:
-        value = &stmt->currentRow->roomTopic;
-        break;
-    case 6:
-        value = &stmt->currentRow->roomPassword;
-        break;
-    case 7:
-        value = &stmt->currentRow->roomPrefix;
-        break;
-    case 8:
-        value = &stmt->currentRow->roomAddress;
-        break;
-    default:
+    if (stmt->type == StatementType::ShowColumns) {
+        if (column == 1 && stmt->showColumnHasRow && stmt->showColumnReturned) {
+            return static_cast<int>(stmt->showColumnType.size());
+        }
         return 0;
     }
 
-    return static_cast<int>(value->size());
+    if (!stmt->currentRow || stmt->type != StatementType::RoomSelect) {
+        return 0;
+    }
+
+    const unsigned char* text = mariadb_column_text(stmt, column);
+    if (!text) {
+        return 0;
+    }
+    return static_cast<int>(std::strlen(reinterpret_cast<const char*>(text)));
 }
 
-std::int64_t mariadb_last_insert_rowid(MariaDBConnection*) {
-    return 0;
-}
+std::int64_t mariadb_last_insert_rowid(MariaDBConnection*) { return 0; }
 

--- a/tests/stationchat/FakeMariaDB.hpp
+++ b/tests/stationchat/FakeMariaDB.hpp
@@ -2,7 +2,9 @@
 
 #include "MariaDB.hpp"
 
+#include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 struct FakeRoomRow {
@@ -22,9 +24,63 @@ struct FakeRoomRow {
     int nodeLevel{0};
 };
 
+struct FakeColumnDefinition {
+    std::string typeName;
+    bool isDateTime{false};
+};
+
+struct FakeTimestampValue {
+    bool isNull{true};
+    bool isDateTime{false};
+    std::string textValue;
+    uint32_t intValue{0};
+};
+
+struct FakeUserLinkRow {
+    uint32_t userId{0};
+    uint32_t avatarId{0};
+    std::string avatarName;
+    FakeTimestampValue createdAt;
+    FakeTimestampValue updatedAt;
+};
+
+struct FakeStatusRow {
+    uint32_t avatarId{0};
+    uint32_t userId{0};
+    std::string avatarName;
+    bool isOnline{false};
+    FakeTimestampValue lastLogin;
+    FakeTimestampValue lastLogout;
+    FakeTimestampValue updatedAt;
+    FakeTimestampValue createdAt;
+};
+
+struct FakeMailRow {
+    uint32_t avatarId{0};
+    uint32_t userId{0};
+    std::string avatarName;
+    uint32_t messageId{0};
+    std::string senderName;
+    std::string senderAddress;
+    std::string subject;
+    std::string body;
+    std::string oob;
+    uint32_t sentTime{0};
+    FakeTimestampValue createdAt;
+    FakeTimestampValue updatedAt;
+    uint32_t status{0};
+};
+
 struct MariaDBConnection {
     std::vector<FakeRoomRow> roomRows;
     std::string lastError{"OK"};
     std::string lastPreparedSql;
+    std::string userLinkTableName;
+    std::string statusTableName;
+    std::string mailTableName;
+    std::unordered_map<std::string, std::unordered_map<std::string, FakeColumnDefinition>> tableColumns;
+    std::unordered_map<std::string, std::vector<FakeUserLinkRow>> userLinkRows;
+    std::unordered_map<std::string, std::vector<FakeStatusRow>> statusRows;
+    std::unordered_map<std::string, std::vector<FakeMailRow>> mailRows;
 };
 

--- a/tests/stationchat/WebsiteIntegrationService_Tests.cpp
+++ b/tests/stationchat/WebsiteIntegrationService_Tests.cpp
@@ -1,0 +1,125 @@
+#include "WebsiteIntegrationService.hpp"
+
+#include "FakeMariaDB.hpp"
+#include "PersistentMessage.hpp"
+#include "StationChatConfig.hpp"
+#include "StringUtils.hpp"
+
+#include "catch.hpp"
+
+#define private public
+#include "stationchat/ChatAvatar.hpp"
+#undef private
+
+namespace {
+
+StationChatConfig MakeConfig() {
+    StationChatConfig config;
+    config.websiteIntegration.enabled = true;
+    config.websiteIntegration.userLinkTable = "web_user_avatar";
+    config.websiteIntegration.onlineStatusTable = "web_avatar_status";
+    config.websiteIntegration.mailTable = "web_persistent_message";
+    return config;
+}
+
+void ConfigureColumn(MariaDBConnection& db, const std::string& table, const std::string& column, bool isDateTime) {
+    FakeColumnDefinition def;
+    def.typeName = isDateTime ? "datetime" : "int";
+    def.isDateTime = isDateTime;
+    db.tableColumns[table][column] = std::move(def);
+}
+
+std::string Narrow(const std::u16string& value) {
+    return FromWideString(value);
+}
+
+ChatAvatar MakeAvatar(uint32_t avatarId, uint32_t userId, const std::u16string& name) {
+    ChatAvatar avatar{nullptr};
+    avatar.avatarId_ = avatarId;
+    avatar.userId_ = userId;
+    avatar.name_ = name;
+    return avatar;
+}
+
+} // namespace
+
+TEST_CASE("Website integration upserts login and status records", "[stationchat][website]") {
+    MariaDBConnection db;
+    auto config = MakeConfig();
+
+    db.userLinkTableName = config.websiteIntegration.userLinkTable;
+    db.statusTableName = config.websiteIntegration.onlineStatusTable;
+    db.mailTableName = config.websiteIntegration.mailTable;
+
+    ConfigureColumn(db, db.userLinkTableName, "created_at", true);
+    ConfigureColumn(db, db.userLinkTableName, "updated_at", true);
+    ConfigureColumn(db, db.statusTableName, "created_at", true);
+    ConfigureColumn(db, db.statusTableName, "updated_at", true);
+    ConfigureColumn(db, db.statusTableName, "last_login", true);
+    ConfigureColumn(db, db.statusTableName, "last_logout", true);
+    ConfigureColumn(db, db.mailTableName, "created_at", true);
+    ConfigureColumn(db, db.mailTableName, "updated_at", true);
+
+    WebsiteIntegrationService service{&db, config};
+    REQUIRE(service.IsEnabled());
+
+    auto avatar = MakeAvatar(42, 777, u"Integration Tester");
+
+    service.RecordAvatarLogin(avatar);
+
+    auto& linkRows = db.userLinkRows[db.userLinkTableName];
+    REQUIRE(linkRows.size() == 1);
+    const auto& link = linkRows.front();
+    CHECK(link.avatarId == avatar.GetAvatarId());
+    CHECK(link.userId == avatar.GetUserId());
+    CHECK(link.avatarName == Narrow(avatar.GetName()));
+    CHECK_FALSE(link.createdAt.isNull);
+    CHECK_FALSE(link.updatedAt.isNull);
+
+    auto& statusRows = db.statusRows[db.statusTableName];
+    REQUIRE(statusRows.size() == 1);
+    const auto& status = statusRows.front();
+    CHECK(status.avatarId == avatar.GetAvatarId());
+    CHECK(status.isOnline);
+    CHECK_FALSE(status.lastLogin.isNull);
+    CHECK(status.lastLogout.isNull);
+    auto loginTimestamp = status.lastLogin.textValue;
+
+    service.RecordAvatarLogout(avatar);
+
+    REQUIRE(statusRows.size() == 1);
+    const auto& updatedStatus = statusRows.front();
+    CHECK_FALSE(updatedStatus.isOnline);
+    CHECK_FALSE(updatedStatus.lastLogout.isNull);
+    CHECK(updatedStatus.lastLogin.textValue == loginTimestamp);
+
+    PersistentMessage message;
+    message.header.messageId = 9001;
+    message.header.fromName = u"Sender";
+    message.header.fromAddress = u"sender@example.com";
+    message.header.subject = u"Integration Test";
+    message.header.sentTime = 12345;
+    message.header.status = PersistentState::UNREAD;
+    message.message = u"Body";
+    message.oob = u"OOB";
+
+    service.RecordPersistentMessage(avatar, message);
+
+    auto& mailRows = db.mailRows[db.mailTableName];
+    REQUIRE(mailRows.size() == 1);
+    const auto& mail = mailRows.front();
+    CHECK(mail.avatarId == avatar.GetAvatarId());
+    CHECK(mail.userId == avatar.GetUserId());
+    CHECK(mail.messageId == message.header.messageId);
+    CHECK(mail.senderName == Narrow(message.header.fromName));
+    CHECK(mail.senderAddress == Narrow(message.header.fromAddress));
+    CHECK(mail.subject == Narrow(message.header.subject));
+    CHECK(mail.body == Narrow(message.message));
+    CHECK(mail.oob == Narrow(message.oob));
+    CHECK(mail.sentTime == message.header.sentTime);
+    CHECK(mail.status == static_cast<uint32_t>(message.header.status));
+    CHECK_FALSE(mail.createdAt.isNull);
+    CHECK_FALSE(mail.updatedAt.isNull);
+
+    REQUIRE(linkRows.size() == 1);
+}


### PR DESCRIPTION
## Summary
- cache prepared statements inside `WebsiteIntegrationService` and reuse them for all updates
- extend the MariaDB shim with a statement reset helper and richer fake database behavior for website data
- add integration-style tests that verify website synchronization produces the expected rows

## Testing
- `cmake -S . -B build` *(fails: missing udplibrary dependency in externals directory)*

------
https://chatgpt.com/codex/tasks/task_e_68fb6b6ca2c8832cac370d85233eea5d