### PR TITLE
Cache SHOW COLUMNS statements in WebsiteIntegrationService

### DIFF
--- a/src/stationchat/WebsiteIntegrationService.hpp
+++ b/src/stationchat/WebsiteIntegrationService.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 class ChatAvatar;
@@ -65,6 +66,11 @@ private:
         int statusIdx{0};
     };
 
+    struct PreparedShowColumnsStatement {
+        MariaDBStatement* handle{nullptr};
+        int columnNameIdx{0};
+    };
+
     void EnsureUserLink(const ChatAvatar& avatar);
     void UpdateOnlineStatus(const ChatAvatar& avatar, bool isOnline);
     ColumnInfo InspectColumn(const std::string& table, const std::string& column);
@@ -93,4 +99,5 @@ private:
     PreparedUserLinkStatement userLinkStmt_;
     PreparedStatusStatement statusStmt_;
     PreparedMailStatement mailStmt_;
+    std::unordered_map<std::string, PreparedShowColumnsStatement> showColumnsStatements_;
 };

--- a/tests/stationchat/FakeMariaDB.cpp
+++ b/tests/stationchat/FakeMariaDB.cpp
@@ -332,6 +332,7 @@ int mariadb_prepare(MariaDBConnection* db, const char* sql, int, MariaDBStatemen
     statement->sql = sql;
     db->lastPreparedSql = sql;
     db->lastError = "OK";
+    db->preparedStatementCount[sql] += 1;
 
     ParseParameterNames(statement);
     DetermineStatementType(statement);

--- a/tests/stationchat/FakeMariaDB.hpp
+++ b/tests/stationchat/FakeMariaDB.hpp
@@ -82,5 +82,6 @@ struct MariaDBConnection {
     std::unordered_map<std::string, std::vector<FakeUserLinkRow>> userLinkRows;
     std::unordered_map<std::string, std::vector<FakeStatusRow>> statusRows;
     std::unordered_map<std::string, std::vector<FakeMailRow>> mailRows;
+    std::unordered_map<std::string, int> preparedStatementCount;
 };
 


### PR DESCRIPTION
## Summary
- cache SHOW COLUMNS prepared statements inside WebsiteIntegrationService and clean them up during destruction
- extend the stationchat MariaDB test double to track prepared statement usage counts
- add an integration-style test verifying website sync populates rows while reusing schema inspection statements

## Testing
- `cmake -S . -B build` *(fails: udplibrary dependency is not present in externals/)*

------
https://chatgpt.com/codex/tasks/task_e_68fb6ee446fc832c80fce638303e485a