### PR TITLE
Replace std::optional usage with boost::optional for C++14 builds

### DIFF
--- a/src/stationapi/StringUtils.cpp
+++ b/src/stationapi/StringUtils.cpp
@@ -2,7 +2,7 @@
 
 #include <codecvt>
 #include <locale>
-#include <optional>
+#include <boost/optional.hpp>
 
 std::string FromWideString(const std::u16string& str) {
     std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> converter;
@@ -14,9 +14,9 @@ std::u16string ToWideString(const std::string& str) {
     return converter.from_bytes(str);
 }
 
-std::optional<std::u16string> NullableUtf8ToWide(const unsigned char* buffer) {
+boost::optional<std::u16string> NullableUtf8ToWide(const unsigned char* buffer) {
     if (!buffer) {
-        return std::nullopt;
+        return boost::none;
     }
 
     const auto utf8 = reinterpret_cast<const char*>(buffer);

--- a/src/stationapi/StringUtils.hpp
+++ b/src/stationapi/StringUtils.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <optional>
 #include <string>
+#include <boost/optional.hpp>
 
 std::string FromWideString(const std::u16string& str);
 std::u16string ToWideString(const std::string& str);
-std::optional<std::u16string> NullableUtf8ToWide(const unsigned char* buffer);
+boost::optional<std::u16string> NullableUtf8ToWide(const unsigned char* buffer);
 

--- a/tests/stationchat/FakeMariaDB.cpp
+++ b/tests/stationchat/FakeMariaDB.cpp
@@ -4,7 +4,7 @@
 #include <cctype>
 #include <cstdint>
 #include <cstring>
-#include <optional>
+#include <boost/optional.hpp>
 #include <unordered_map>
 #include <utility>
 
@@ -197,10 +197,10 @@ const BoundParameter* GetBinding(const MariaDBStatement* stmt, const std::string
     return &stmt->bindings[static_cast<std::size_t>(index - 1)];
 }
 
-std::optional<int> GetIntParameter(const MariaDBStatement* stmt, const std::string& name) {
+boost::optional<int> GetIntParameter(const MariaDBStatement* stmt, const std::string& name) {
     const auto* binding = GetBinding(stmt, name);
     if (!binding || binding->isNull) {
-        return std::nullopt;
+        return boost::none;
     }
     if (binding->kind == BoundParameter::Kind::Int) {
         return binding->intValue;
@@ -209,16 +209,16 @@ std::optional<int> GetIntParameter(const MariaDBStatement* stmt, const std::stri
         try {
             return std::stoi(binding->textValue);
         } catch (...) {
-            return std::nullopt;
+            return boost::none;
         }
     }
-    return std::nullopt;
+    return boost::none;
 }
 
-std::optional<std::string> GetTextParameter(const MariaDBStatement* stmt, const std::string& name) {
+boost::optional<std::string> GetTextParameter(const MariaDBStatement* stmt, const std::string& name) {
     const auto* binding = GetBinding(stmt, name);
     if (!binding || binding->isNull) {
-        return std::nullopt;
+        return boost::none;
     }
     if (binding->kind == BoundParameter::Kind::Text) {
         return binding->textValue;
@@ -226,7 +226,7 @@ std::optional<std::string> GetTextParameter(const MariaDBStatement* stmt, const 
     if (binding->kind == BoundParameter::Kind::Int) {
         return std::to_string(binding->intValue);
     }
-    return std::nullopt;
+    return boost::none;
 }
 
 const FakeColumnDefinition* FindColumnDefinition(const MariaDBConnection* connection,


### PR DESCRIPTION
## Summary
- replace std::optional usage with boost::optional in the string utilities to maintain C++14 compatibility
- update the test fake MariaDB helper to use boost::optional and include the required header

## Testing
- cmake -S . -B build *(fails: udplibrary required... copy from swg source to the externals directory)*

------
https://chatgpt.com/codex/tasks/task_e_68fb86bc034c832cadde13c1414f647b