### PR TITLE
Fix ChatRoomService test include path

### DIFF
--- a/tests/stationchat/ChatRoomService_Tests.cpp
+++ b/tests/stationchat/ChatRoomService_Tests.cpp
@@ -1,4 +1,4 @@
-#include "ChatRoomService.hpp"
+#include "stationchat/ChatRoomService.hpp"
 
 #include "FakeMariaDB.hpp"
 


### PR DESCRIPTION
## Summary
- update the ChatRoomService test to include the header via the public stationchat include path so the build can locate it

## Testing
- cmake -S . -B build *(fails: udplibrary required in externals directory)*

------
https://chatgpt.com/codex/tasks/task_e_68fb8879cee4832cbeb681faf9447e42