### PR TITLE
Fix FakeMariaDB include path

### DIFF
--- a/tests/stationchat/FakeMariaDB.hpp
+++ b/tests/stationchat/FakeMariaDB.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "MariaDB.hpp"
+#include "stationapi/MariaDB.hpp"
 
 #include <optional>
 #include <string>


### PR DESCRIPTION
## Summary
- update FakeMariaDB to include the MariaDB header via its stationapi-qualified path so it can be found during test builds

## Testing
- cmake -S . -B build (fails: requires udplibrary in externals)


------
https://chatgpt.com/codex/tasks/task_e_68fb8a0298cc832c9f86254b8bb844e7