### PR TITLE
Fix test stub include path

### DIFF
--- a/tests/stationchat/StubChatAvatarService.cpp
+++ b/tests/stationchat/StubChatAvatarService.cpp
@@ -1,4 +1,4 @@
-#include "ChatAvatarService.hpp"
+#include "stationchat/ChatAvatarService.hpp"
 
 ChatAvatarService::ChatAvatarService(MariaDBConnection* db)
     : db_{db} {}


### PR DESCRIPTION
## Summary
- adjust the test double for ChatAvatarService to include the header via the stationchat include directory so it resolves during builds

## Testing
- cmake -S stationapiv2.2 -B stationapiv2.2/build *(fails: udplibrary dependency missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fb8bd7415c832cb005957bc9d31121