### PR TITLE
Ensure tests can locate Serialization header

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 include_directories(${PROJECT_SOURCE_DIR}/externals/catch
-    ${PROJECT_SOURCE_DIR}/src)
+    ${PROJECT_SOURCE_DIR}/src
+    ${PROJECT_SOURCE_DIR}/src/stationapi)
 
 add_executable(stationapi_tests
     main.cpp

--- a/tests/stationchat/StubChatAvatarService.cpp
+++ b/tests/stationchat/StubChatAvatarService.cpp
@@ -1,4 +1,4 @@
-#include "ChatAvatarService.hpp"
+#include "stationchat/ChatAvatarService.hpp"
 
 ChatAvatarService::ChatAvatarService(MariaDBConnection* db)
     : db_{db} {}


### PR DESCRIPTION
## Summary
- add the stationapi include directory to the shared test include path so Serialization.hpp resolves when compiling chat tests

## Testing
- cmake -S . -B build *(fails: udplibrary dependency missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fb8bd7415c832cb005957bc9d31121