### PR TITLE
Improve MariaDB connection failure diagnostics

### DIFF
--- a/src/stationapi/MariaDB.cpp
+++ b/src/stationapi/MariaDB.cpp
@@ -328,12 +328,12 @@ int mariadb_open(const char* connectionString, MariaDBConnection** db) {
         info = ParseConnectionString(connectionString ? connectionString : "");
     } catch (const std::exception& ex) {
         SetError(connection, ex.what());
-        delete connection;
+        *db = connection;
         return MARIADB_ERROR;
     }
     if (info.user.empty() || info.database.empty()) {
         SetError(connection, "MariaDB connection string must include user and database");
-        delete connection;
+        *db = connection;
         return MARIADB_ERROR;
     }
 
@@ -345,7 +345,7 @@ int mariadb_open(const char* connectionString, MariaDBConnection** db) {
     connection->socketPath = info.socketPath;
 
     if (!Connect(connection)) {
-        delete connection;
+        *db = connection;
         return MARIADB_ERROR;
     }
 

--- a/src/stationchat/GatewayNode.cpp
+++ b/src/stationchat/GatewayNode.cpp
@@ -10,11 +10,17 @@
 
 GatewayNode::GatewayNode(StationChatConfig& config)
     : Node(this, config.gatewayAddress, config.gatewayPort, config.bindToIp)
-    , config_{config} {
+    , config_{config}
+    , db_{nullptr} {
     auto connectionString = config.BuildDatabaseConnectionString();
-    if (mariadb_open(connectionString.c_str(), &db_) != MARIADB_OK) {
-        throw std::runtime_error("Can't open database: " + std::string{mariadb_errmsg(db_)});
+    MariaDBConnection* connection{nullptr};
+    if (mariadb_open(connectionString.c_str(), &connection) != MARIADB_OK) {
+        const std::string errorMessage = connection ? mariadb_errmsg(connection) : "Unknown MariaDB error";
+        mariadb_close(connection);
+        throw std::runtime_error("Can't open database: " + errorMessage);
     }
+
+    db_ = connection;
 
     avatarService_ = std::make_unique<ChatAvatarService>(db_);
     roomService_ = std::make_unique<ChatRoomService>(avatarService_.get(), db_);

--- a/src/stationchat/WebsiteIntegrationService.cpp
+++ b/src/stationchat/WebsiteIntegrationService.cpp
@@ -202,7 +202,9 @@ WebsiteIntegrationService::WebsiteIntegrationService(MariaDBConnection* db, cons
     if (config.websiteIntegration.useSeparateDatabase) {
         MariaDBConnection* integrationDb = nullptr;
         if (mariadb_open(connectionString.c_str(), &integrationDb) != MARIADB_OK) {
-            throw std::runtime_error("Can't open website integration database connection");
+            const std::string errorMessage = integrationDb ? mariadb_errmsg(integrationDb) : "Unknown MariaDB error";
+            mariadb_close(integrationDb);
+            throw std::runtime_error("Can't open website integration database connection: " + errorMessage);
         }
 
         db_ = integrationDb;


### PR DESCRIPTION
## Summary
- preserve the MariaDB connection handle on `mariadb_open` failures so callers can retrieve the detailed error message
- ensure the gateway and website integration services surface those detailed messages and clean up failed handles

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68fb9d4bfb54832c94ab13e634218539