### PR TITLE
Add bundled UDP stub and refresh build guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-externals/udplibrary
 build*/
 .vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,10 @@ include(ModernCpp)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 if (EXISTS "${PROJECT_SOURCE_DIR}/externals/udplibrary/CMakeLists.txt")
-    message(STATUS "Detected udplibrary")
+    message(STATUS "Detected udplibrary sources in externals/udplibrary")
     set(HAVE_UDPLIBRARY 1)
 else()
-    message(FATAL_ERROR "udplibrary required... copy from swg source to the externals directory")
+    message(FATAL_ERROR "Missing externals/udplibrary. Restore the bundled stub or provide the proprietary library.")
 endif()
 
 add_definitions(-DBOOST_ALL_NO_LIB)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ and extend.
 | C++14-compatible compiler | Builds the `stationchat` gateway binaries |
 | [Boost.Program_options](https://www.boost.org/doc/libs/release/doc/html/program_options.html) | Parses configuration flags and files |
 | [MariaDB Client Libraries](https://mariadb.com/kb/en/mariadb-client-library/) | Provides database connectivity |
-| `udplibrary` | Proprietary dependency from the original SWG source; copy it into `externals/` |
+| `udplibrary` | Bundled open-source stub of the proprietary UDP manager. Replace it with the original library when a licensed copy is available. |
 | [Apache Ant](https://ant.apache.org/) *(optional)* | Supplies a compatibility wrapper that mirrors historical build workflows |
 
 ---
@@ -42,7 +42,7 @@ The build can be completed entirely on a Raspberry Pi or any modern Linux
 distribution. Expect three high-level phases:
 
 1. **Install prerequisite packages** – compiler, libraries, and helper tools.
-2. **Fetch the source code and proprietary UDP dependency.**
+2. **Fetch the source code (a stub UDP library is bundled; drop in the proprietary one if you have access).**
 3. **Compile and install the chat gateway.**
 
 ### Quick-start bootstrap script
@@ -55,13 +55,12 @@ sudo apt install git ant build-essential cmake \
     libboost-program-options-dev libmariadb-dev libmariadb-dev-compat libatomic1
 git clone https://github.com/polsommer/stationapi
 cd stationapi
-cp -r /path/to/original/udplibrary ./externals/
 ./extras/bootstrap_build.sh
 ```
 
 What the script does:
 
-1. Ensures `externals/udplibrary` is present (cloning it when available).
+1. Ensures `externals/udplibrary` is present. The repository ships with an open-source stub so manual steps are rarely required.
 2. Configures and builds the CMake project.
 3. Installs the runtime, default configuration files, and a `stationchat`
    launcher into `/home/swg/chat`.
@@ -162,10 +161,10 @@ Under the hood this target simply calls the same `cmake -S . -B build` and
 `cmake --install build --prefix /home/swg/chat`, then runs the same
 `extras/finalize_chat_install.sh` helper to drop the launcher and symlink. The
 wrapper performs a quick check before invoking CMake and stops early with a
-clear error if `externals/udplibrary` is missing so you know to copy the
-proprietary library over before retrying. Pass `-Dinstall.prefix=/path/to/chatdir`
-if you need a different install location and `-Drun.link=/path/to/link` to
-override the symlink destination.
+clear error if `externals/udplibrary` is missing so you can restore the bundled
+stub or provide the original proprietary library before retrying. Pass
+`-Dinstall.prefix=/path/to/chatdir` if you need a different install location and
+`-Drun.link=/path/to/link` to override the symlink destination.
 
 To remove build artifacts created by either approach, run:
 

--- a/build.xml
+++ b/build.xml
@@ -14,9 +14,9 @@
 
     <target name="require-udplibrary">
         <fail unless="udplibrary.present">
-            Missing externals/udplibrary. Copy the proprietary udplibrary from the
-            original SWG source into externals/udplibrary before running this
-            target.
+            Missing externals/udplibrary. Restore the bundled open-source stub or
+            copy the proprietary udplibrary from the original SWG source into
+            externals/udplibrary before running this target.
         </fail>
     </target>
 

--- a/externals/udplibrary/CMakeLists.txt
+++ b/externals/udplibrary/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library(udplibrary
+    src/UdpLibrary.cpp)
+
+add_library(udplibrary::udplibrary ALIAS udplibrary)
+
+target_include_directories(
+    udplibrary
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+target_compile_features(udplibrary PUBLIC cxx_std_17)

--- a/externals/udplibrary/include/UdpLibrary.hpp
+++ b/externals/udplibrary/include/UdpLibrary.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+using uchar = unsigned char;
+
+constexpr int cUdpChannelReliable1 = 0;
+
+class UdpConnection;
+
+class UdpConnectionHandler {
+public:
+    virtual ~UdpConnectionHandler() = default;
+    virtual void OnRoutePacket(UdpConnection* connection, const uchar* data, int length) = 0;
+};
+
+class UdpManagerHandler {
+public:
+    virtual ~UdpManagerHandler() = default;
+    virtual void OnConnectRequest(UdpConnection* connection) = 0;
+};
+
+class UdpIpAddress {
+public:
+    UdpIpAddress();
+    explicit UdpIpAddress(std::string address);
+
+    const char* GetAddress(char* buffer) const;
+    void SetAddress(std::string address);
+
+private:
+    std::string address_;
+};
+
+class UdpConnection {
+public:
+    enum Status { cStatusConnected, cStatusDisconnected };
+
+    UdpConnection();
+
+    void AddRef();
+    void Release();
+
+    void SetHandler(UdpConnectionHandler* handler);
+    void Disconnect();
+    void Send(int channel, const char* data, uint32_t length);
+
+    Status GetStatus() const;
+    const UdpIpAddress& GetDestinationIp() const;
+    uint16_t GetDestinationPort() const;
+
+    void SetDestination(const std::string& address, uint16_t port);
+    void SimulateIncoming(const uchar* data, int length);
+
+private:
+    std::atomic<int> refCount_;
+    Status status_;
+    UdpConnectionHandler* handler_;
+    UdpIpAddress destination_;
+    uint16_t destinationPort_;
+};
+
+class UdpManager {
+public:
+    struct Params {
+        UdpManagerHandler* handler = nullptr;
+        uint16_t port = 0;
+        char bindIpAddress[256] = {0};
+    };
+
+    explicit UdpManager(const Params* params);
+    ~UdpManager();
+
+    void Release();
+    void GiveTime();
+
+    UdpConnection* CreateConnection();
+
+private:
+    UdpManagerHandler* handler_;
+    uint16_t listenPort_;
+};
+

--- a/externals/udplibrary/src/UdpLibrary.cpp
+++ b/externals/udplibrary/src/UdpLibrary.cpp
@@ -1,0 +1,94 @@
+#include "UdpLibrary.hpp"
+
+#include <algorithm>
+#include <utility>
+
+namespace {
+constexpr std::size_t UDP_ADDRESS_BUFFER = 256;
+}
+
+UdpIpAddress::UdpIpAddress() : address_{"0.0.0.0"} {}
+
+UdpIpAddress::UdpIpAddress(std::string address) : address_{std::move(address)} {}
+
+const char* UdpIpAddress::GetAddress(char* buffer) const {
+    if (buffer == nullptr) {
+        return address_.c_str();
+    }
+
+    std::fill_n(buffer, UDP_ADDRESS_BUFFER, '\0');
+    auto to_copy = std::min(address_.size(), UDP_ADDRESS_BUFFER - 1);
+    std::copy_n(address_.data(), to_copy, buffer);
+    buffer[to_copy] = '\0';
+    return buffer;
+}
+
+void UdpIpAddress::SetAddress(std::string address) { address_ = std::move(address); }
+
+UdpConnection::UdpConnection()
+    : refCount_{1}
+    , status_{cStatusConnected}
+    , handler_{nullptr}
+    , destination_{"0.0.0.0"}
+    , destinationPort_{0} {}
+
+void UdpConnection::AddRef() { ++refCount_; }
+
+void UdpConnection::Release() {
+    if (--refCount_ == 0) {
+        delete this;
+    }
+}
+
+void UdpConnection::SetHandler(UdpConnectionHandler* handler) { handler_ = handler; }
+
+void UdpConnection::Disconnect() { status_ = cStatusDisconnected; }
+
+void UdpConnection::Send(int, const char*, uint32_t) {
+    // The open-source stub does not implement real networking. This method is
+    // intentionally a no-op so that the rest of the application can be tested
+    // without the proprietary dependency.
+}
+
+UdpConnection::Status UdpConnection::GetStatus() const { return status_; }
+
+const UdpIpAddress& UdpConnection::GetDestinationIp() const { return destination_; }
+
+uint16_t UdpConnection::GetDestinationPort() const { return destinationPort_; }
+
+void UdpConnection::SetDestination(const std::string& address, uint16_t port) {
+    destination_.SetAddress(address);
+    destinationPort_ = port;
+}
+
+void UdpConnection::SimulateIncoming(const uchar* data, int length) {
+    if (handler_ == nullptr || data == nullptr || length <= 0 || status_ != cStatusConnected) {
+        return;
+    }
+
+    handler_->OnRoutePacket(this, data, length);
+}
+
+UdpManager::UdpManager(const Params* params)
+    : handler_{params != nullptr ? params->handler : nullptr}
+    , listenPort_{params != nullptr ? params->port : 0} {}
+
+UdpManager::~UdpManager() = default;
+
+void UdpManager::Release() { delete this; }
+
+void UdpManager::GiveTime() {
+    // Nothing to do in the stub implementation.
+}
+
+UdpConnection* UdpManager::CreateConnection() {
+    auto* connection = new UdpConnection();
+    connection->SetDestination("127.0.0.1", listenPort_);
+
+    if (handler_ != nullptr) {
+        handler_->OnConnectRequest(connection);
+    }
+
+    return connection;
+}
+


### PR DESCRIPTION
## Summary
- add an open-source stub implementation of the UDP library and hook it into the build
- refresh build scripts and documentation to describe the bundled stub and updated guidance
- adjust Ant messaging when the UDP library directory is missing

## Testing
- cmake -S . -B build *(fails: missing Boost program_options headers in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fbb3259d94832c93360825979574a0