### PR TITLE
Update default StationChat configuration values

### DIFF
--- a/extras/swgchat.cfg.dist
+++ b/extras/swgchat.cfg.dist
@@ -1,21 +1,21 @@
 # Address that the gateway server will listen for connections on
-gateway_address = 127.0.0.1
+gateway_address = 192.168.88.6
 
 # Port the gateway server will listen for connections on
 gateway_port = 5001
 
 # Address that the registrar server will listen for connections on
-registrar_address = 127.0.0.1
+registrar_address = 192.168.88.6
 
 # Port the registrar server will listen for connections on
 registrar_port = 5000
 
 # MariaDB connection information
-database_host = 127.0.0.1
+database_host = mysql73.unoeuro.com
 database_port = 3306
-database_user = stationchat
+database_user = swgplus_com
 database_password = 
-database_schema = stationchat
+database_schema = swgplus_com_db
 # For local socket connections leave host empty and configure the socket path
 database_socket =
 
@@ -23,7 +23,7 @@ database_socket =
 bind_to_ip = false
 
 # When enabled, stationchat will publish avatar state for the website integration
-website_integration_enabled = false
+website_integration_enabled = true
 
 # Database tables used by the website integration (schema must exist beforehand)
 website_user_link_table = web_user_avatar
@@ -36,9 +36,9 @@ website_use_separate_database = false
 
 # Optional database overrides for the website integration. Leave empty (or zero for the port)
 # to reuse the chat database connection settings defined above.
-website_database_host =
-website_database_port = 0
-website_database_user =
+website_database_host = mysql73.unoeuro.com
+website_database_port = 3306
+website_database_user = swgplus_com
 website_database_password =
-website_database_schema =
+website_database_schema = swgplus_com_db
 website_database_socket =

--- a/src/stationchat/StationChatConfig.hpp
+++ b/src/stationchat/StationChatConfig.hpp
@@ -20,16 +20,16 @@ struct GatewayClusterEndpoint {
 };
 
 struct WebsiteIntegrationConfig {
-    bool enabled{false};
+    bool enabled{true};
     std::string userLinkTable{"web_user_avatar"};
     std::string onlineStatusTable{"web_avatar_status"};
     std::string mailTable{"web_persistent_message"};
     bool useSeparateDatabase{false};
-    std::string databaseHost;
-    uint16_t databasePort{0};
-    std::string databaseUser;
+    std::string databaseHost{"mysql73.unoeuro.com"};
+    uint16_t databasePort{3306};
+    std::string databaseUser{"swgplus_com"};
     std::string databasePassword;
-    std::string databaseSchema;
+    std::string databaseSchema{"swgplus_com_db"};
     std::string databaseSocket;
 };
 
@@ -67,15 +67,15 @@ struct StationChatConfig {
     // Maintain compatibility with existing Star Wars Galaxies chat clients,
     // which expect protocol version 2 during the SETAPIVERSION handshake.
     const uint32_t version = 2;
-    std::string gatewayAddress{"127.0.0.1"};
+    std::string gatewayAddress{"192.168.88.6"};
     uint16_t gatewayPort{5001};
-    std::string registrarAddress{"127.0.0.1"};
+    std::string registrarAddress{"192.168.88.6"};
     uint16_t registrarPort{5000};
-    std::string chatDatabaseHost{"127.0.0.1"};
+    std::string chatDatabaseHost{"mysql73.unoeuro.com"};
     uint16_t chatDatabasePort{3306};
-    std::string chatDatabaseUser{"stationchat"};
+    std::string chatDatabaseUser{"swgplus_com"};
     std::string chatDatabasePassword;
-    std::string chatDatabaseSchema{"stationchat"};
+    std::string chatDatabaseSchema{"swgplus_com_db"};
     std::string chatDatabaseSocket;
     std::string loggerConfig;
     bool bindToIp{false};

--- a/src/stationchat/main.cpp
+++ b/src/stationchat/main.cpp
@@ -156,29 +156,29 @@ StationChatConfig BuildConfiguration(int argc, const char* argv[]) {
 
     po::options_description options("Configuration");
     options.add_options()
-        ("gateway_address", po::value<std::string>(&config.gatewayAddress)->default_value("127.0.0.1"),
+        ("gateway_address", po::value<std::string>(&config.gatewayAddress)->default_value("192.168.88.6"),
             "address for gateway connections")
         ("gateway_port", po::value<uint16_t>(&config.gatewayPort)->default_value(5001),
             "port for gateway connections")
-        ("registrar_address", po::value<std::string>(&config.registrarAddress)->default_value("127.0.0.1"),
+        ("registrar_address", po::value<std::string>(&config.registrarAddress)->default_value("192.168.88.6"),
             "address for registrar connections")
         ("registrar_port", po::value<uint16_t>(&config.registrarPort)->default_value(5000),
             "port for registrar connections")
         ("bind_to_ip", po::value<bool>(&config.bindToIp)->default_value(false),
             "when set to true, binds to the config address; otherwise, binds on any interface")
-        ("database_host", po::value<std::string>(&config.chatDatabaseHost)->default_value("127.0.0.1"),
+        ("database_host", po::value<std::string>(&config.chatDatabaseHost)->default_value("mysql73.unoeuro.com"),
             "hostname or IP address of the MariaDB server")
         ("database_port", po::value<uint16_t>(&config.chatDatabasePort)->default_value(3306),
             "port for the MariaDB server")
-        ("database_user", po::value<std::string>(&config.chatDatabaseUser)->default_value("stationchat"),
+        ("database_user", po::value<std::string>(&config.chatDatabaseUser)->default_value("swgplus_com"),
             "username used to connect to MariaDB")
         ("database_password", po::value<std::string>(&config.chatDatabasePassword)->default_value(""),
             "password used to connect to MariaDB")
-        ("database_schema", po::value<std::string>(&config.chatDatabaseSchema)->default_value("stationchat"),
+        ("database_schema", po::value<std::string>(&config.chatDatabaseSchema)->default_value("swgplus_com_db"),
             "schema (database) name used by stationchat")
         ("database_socket", po::value<std::string>(&config.chatDatabaseSocket)->default_value(""),
             "optional UNIX socket path for local MariaDB connections")
-        ("website_integration_enabled", po::value<bool>(&config.websiteIntegration.enabled)->default_value(false),
+        ("website_integration_enabled", po::value<bool>(&config.websiteIntegration.enabled)->default_value(true),
             "when true, publishes chat status information for consumption by the website")
         ("website_user_link_table", po::value<std::string>(&config.websiteIntegration.userLinkTable)->default_value("web_user_avatar"),
             "table used to associate chat avatars with website accounts")
@@ -188,15 +188,15 @@ StationChatConfig BuildConfiguration(int argc, const char* argv[]) {
             "table used to expose persistent mail to the website")
         ("website_use_separate_database", po::value<bool>(&config.websiteIntegration.useSeparateDatabase)->default_value(false),
             "when true, uses a dedicated database connection for the website integration")
-        ("website_database_host", po::value<std::string>(&config.websiteIntegration.databaseHost)->default_value(""),
+        ("website_database_host", po::value<std::string>(&config.websiteIntegration.databaseHost)->default_value("mysql73.unoeuro.com"),
             "optional override for the website integration database host")
-        ("website_database_port", po::value<uint16_t>(&config.websiteIntegration.databasePort)->default_value(0),
+        ("website_database_port", po::value<uint16_t>(&config.websiteIntegration.databasePort)->default_value(3306),
             "optional override for the website integration database port")
-        ("website_database_user", po::value<std::string>(&config.websiteIntegration.databaseUser)->default_value(""),
+        ("website_database_user", po::value<std::string>(&config.websiteIntegration.databaseUser)->default_value("swgplus_com"),
             "optional override for the website integration database user")
         ("website_database_password", po::value<std::string>(&config.websiteIntegration.databasePassword)->default_value(""),
             "optional override for the website integration database password")
-        ("website_database_schema", po::value<std::string>(&config.websiteIntegration.databaseSchema)->default_value(""),
+        ("website_database_schema", po::value<std::string>(&config.websiteIntegration.databaseSchema)->default_value("swgplus_com_db"),
             "optional override for the website integration database schema")
         ("website_database_socket", po::value<std::string>(&config.websiteIntegration.databaseSocket)->default_value(""),
             "optional override for the website integration database socket path")


### PR DESCRIPTION
## Summary
- update the default configuration template and in-code defaults to use the provided gateway, registrar, and database settings
- enable website integration by default and align its optional overrides with the supplied database information

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fbbbaf1388832cae64eb5061204261