### PR TITLE
Improve MariaDB connection error reporting

### DIFF
--- a/src/stationapi/MariaDB.cpp
+++ b/src/stationapi/MariaDB.cpp
@@ -322,18 +322,17 @@ int mariadb_open(const char* connectionString, MariaDBConnection** db) {
     EnsureMariaDBInitialized();
 
     auto* connection = new MariaDBConnection();
+    *db = connection;
 
     ConnectionInfo info;
     try {
         info = ParseConnectionString(connectionString ? connectionString : "");
     } catch (const std::exception& ex) {
         SetError(connection, ex.what());
-        delete connection;
         return MARIADB_ERROR;
     }
     if (info.user.empty() || info.database.empty()) {
         SetError(connection, "MariaDB connection string must include user and database");
-        delete connection;
         return MARIADB_ERROR;
     }
 
@@ -345,11 +344,9 @@ int mariadb_open(const char* connectionString, MariaDBConnection** db) {
     connection->socketPath = info.socketPath;
 
     if (!Connect(connection)) {
-        delete connection;
         return MARIADB_ERROR;
     }
 
-    *db = connection;
     return MARIADB_OK;
 }
 

--- a/src/stationchat/GatewayNode.hpp
+++ b/src/stationchat/GatewayNode.hpp
@@ -44,5 +44,5 @@ private:
     std::unique_ptr<WebsiteIntegrationService> websiteIntegrationService_;
     std::map<std::u16string, GatewayClient*> clientAddressMap_;
     StationChatConfig& config_;
-    MariaDBConnection* db_;
+    MariaDBConnection* db_{nullptr};
 };

--- a/src/stationchat/WebsiteIntegrationService.cpp
+++ b/src/stationchat/WebsiteIntegrationService.cpp
@@ -201,8 +201,14 @@ WebsiteIntegrationService::WebsiteIntegrationService(MariaDBConnection* db, cons
     auto connectionString = BuildWebsiteConnectionString(config);
     if (config.websiteIntegration.useSeparateDatabase) {
         MariaDBConnection* integrationDb = nullptr;
-        if (mariadb_open(connectionString.c_str(), &integrationDb) != MARIADB_OK) {
-            throw std::runtime_error("Can't open website integration database connection");
+        auto result = mariadb_open(connectionString.c_str(), &integrationDb);
+        if (result != MARIADB_OK) {
+            std::string errorMessage = integrationDb ? mariadb_errmsg(integrationDb) : "Unknown MariaDB error";
+            if (integrationDb) {
+                mariadb_close(integrationDb);
+                integrationDb = nullptr;
+            }
+            throw std::runtime_error("Can't open website integration database connection: " + errorMessage);
         }
 
         db_ = integrationDb;


### PR DESCRIPTION
## Summary
- keep a MariaDB connection object available after mariadb_open failures so callers can read the stored error message
- harden GatewayNode startup to close failed connections and surface the detailed error text
- surface website integration connection errors with the MariaDB message for easier diagnosis

## Testing
- cmake -S . -B build *(fails: missing Boost program_options headers in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fbbe40bab8832c8c0ac8cb791c091c