### PR TITLE
Add launcher status message for stationchat wrapper

### DIFF
--- a/extras/bootstrap_build.sh
+++ b/extras/bootstrap_build.sh
@@ -1,6 +1,95 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+  cat <<'EOF'
+Usage: bootstrap_build.sh [options]
+
+Ensures the UDP library dependency is present, configures, builds, and installs
+the chat gateway, and finalises the runtime layout.
+
+Options:
+  -d, --debug       Enable verbose debug output (sets shell xtrace).
+  --no-color        Disable coloured status messages.
+  -h, --help        Show this help message and exit.
+EOF
+}
+
+DEBUG=0
+USE_COLOR=1
+
+while (($#)); do
+  case "$1" in
+    -d|--debug)
+      DEBUG=1
+      shift
+      ;;
+    --no-color)
+      USE_COLOR=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "bootstrap_build.sh: unknown option '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if (( DEBUG )); then
+  set -x
+fi
+
+if [[ ! -t 1 ]] || (( USE_COLOR == 0 )); then
+  C_INFO=""
+  C_WARN=""
+  C_ERROR=""
+  C_DEBUG=""
+  C_RESET=""
+else
+  C_INFO="\033[1;34m"
+  C_WARN="\033[1;33m"
+  C_ERROR="\033[1;31m"
+  C_DEBUG="\033[1;35m"
+  C_RESET="\033[0m"
+fi
+
+log_info() {
+  echo -e "${C_INFO}==>${C_RESET} $*"
+}
+
+log_warn() {
+  echo -e "${C_WARN}==> WARNING:${C_RESET} $*" >&2
+}
+
+log_error() {
+  echo -e "${C_ERROR}==> ERROR:${C_RESET} $*" >&2
+}
+
+log_debug() {
+  if (( DEBUG )); then
+    echo -e "${C_DEBUG}[DEBUG]${C_RESET} $*"
+  fi
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    log_error "Required command '$1' not found in PATH. Install it and re-run the bootstrap."
+    exit 1
+  fi
+}
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 UDP_DIR="${REPO_ROOT}/externals/udplibrary"
 INSTALL_PREFIX_DEFAULT="/home/swg/chat"
@@ -8,20 +97,44 @@ INSTALL_PREFIX="${STATIONAPI_CHAT_PREFIX:-${INSTALL_PREFIX_DEFAULT}}"
 RUN_LINK_DEFAULT="/chat"
 RUN_LINK="${STATIONAPI_CHAT_RUNLINK:-${RUN_LINK_DEFAULT}}"
 
+log_debug "Resolved repository root: ${REPO_ROOT}"
+log_info "Using install prefix: ${INSTALL_PREFIX}"
+log_info "Run link target: ${RUN_LINK:-'(none)'}"
+
+require_command git
+require_command cmake
+
 if [[ ! -d "${UDP_DIR}" ]]; then
-  echo "Cloning udplibrary into externals/udplibrary..."
+  log_info "Cloning udplibrary into externals/udplibrary"
   git clone https://bitbucket.org/swgathrawn/udplibrary.git "${UDP_DIR}"
 else
-  echo "udplibrary already present at externals/udplibrary; skipping clone."
+  log_debug "udplibrary already present at ${UDP_DIR}"
+  log_info "Skipping udplibrary clone"
 fi
 
 BUILD_DIR="${REPO_ROOT}/build"
+log_debug "Build directory: ${BUILD_DIR}"
 mkdir -p "${BUILD_DIR}"
 
 pushd "${BUILD_DIR}" >/dev/null
+log_info "Configuring CMake project"
 cmake ..
+
+log_info "Building project"
 cmake --build .
+
+log_info "Installing to ${INSTALL_PREFIX}"
 cmake --install . --prefix "${INSTALL_PREFIX}"
 popd >/dev/null
 
-"${REPO_ROOT}/extras/finalize_chat_install.sh" "${INSTALL_PREFIX}" "${RUN_LINK}"
+FINALIZE_ARGS=()
+if (( DEBUG )); then
+  FINALIZE_ARGS+=(--debug)
+fi
+FINALIZE_ARGS+=("${INSTALL_PREFIX}")
+FINALIZE_ARGS+=("${RUN_LINK}")
+
+log_info "Finalising installation layout"
+"${REPO_ROOT}/extras/finalize_chat_install.sh" "${FINALIZE_ARGS[@]}"
+
+log_info "Bootstrap completed successfully."

--- a/extras/finalize_chat_install.sh
+++ b/extras/finalize_chat_install.sh
@@ -1,58 +1,169 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+  cat <<'EOF'
+Usage: finalize_chat_install.sh [options] <install_prefix> [run_link]
+
+Copies default configuration files, writes the stationchat launcher, and
+optionally creates/updates a symlink for easier startup.
+
+Options:
+  -d, --debug   Enable verbose debug output (sets shell xtrace).
+  --no-color    Disable coloured status messages.
+  -h, --help    Show this help message and exit.
+EOF
+}
+
+DEBUG=0
+USE_COLOR=1
+
+while (($#)); do
+  case "$1" in
+    -d|--debug)
+      DEBUG=1
+      shift
+      ;;
+    --no-color)
+      USE_COLOR=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "finalize_chat_install.sh: unknown option '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if (( DEBUG )); then
+  set -x
+fi
+
+if [[ ! -t 1 ]] || (( USE_COLOR == 0 )); then
+  C_INFO=""
+  C_WARN=""
+  C_ERROR=""
+  C_DEBUG=""
+  C_RESET=""
+else
+  C_INFO="\033[1;34m"
+  C_WARN="\033[1;33m"
+  C_ERROR="\033[1;31m"
+  C_DEBUG="\033[1;35m"
+  C_RESET="\033[0m"
+fi
+
+log_info() {
+  echo -e "${C_INFO}==>${C_RESET} $*"
+}
+
+log_warn() {
+  echo -e "${C_WARN}==> WARNING:${C_RESET} $*" >&2
+}
+
+log_error() {
+  echo -e "${C_ERROR}==> ERROR:${C_RESET} $*" >&2
+}
+
+log_debug() {
+  if (( DEBUG )); then
+    echo -e "${C_DEBUG}[DEBUG]${C_RESET} $*"
+  fi
+}
+
 INSTALL_PREFIX="${1:?Provide an install prefix}"
 RUN_LINK="${2:-/chat}"
 
+log_info "Finalising installation at ${INSTALL_PREFIX}"
+log_info "Run link target: ${RUN_LINK:-'(none)'}"
+
 STATIONCHAT_BIN="${INSTALL_PREFIX}/bin/stationchat"
 if [[ ! -x "${STATIONCHAT_BIN}" ]]; then
-  echo "Error: ${STATIONCHAT_BIN} not found or not executable. Ensure cmake --install completed successfully." >&2
+  log_error "${STATIONCHAT_BIN} not found or not executable. Ensure cmake --install completed successfully."
   exit 1
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+log_debug "Script directory: ${SCRIPT_DIR}"
 
 CONFIG_SOURCE_DIR="${SCRIPT_DIR}"
 CONFIG_TARGET_DIR="${INSTALL_PREFIX}/etc/stationapi"
+log_info "Ensuring configuration directory ${CONFIG_TARGET_DIR} exists"
 mkdir -p "${CONFIG_TARGET_DIR}"
 for cfg in swgchat logger; do
   TARGET_PATH="${CONFIG_TARGET_DIR}/${cfg}.cfg"
   if [[ ! -f "${TARGET_PATH}" ]]; then
     DIST_PATH="${CONFIG_SOURCE_DIR}/${cfg}.cfg.dist"
     if [[ -f "${DIST_PATH}" ]]; then
+      log_info "Copying default ${cfg}.cfg"
       cp "${DIST_PATH}" "${TARGET_PATH}"
-      echo "Copied default ${cfg}.cfg to ${TARGET_PATH}"
     else
-      echo "Warning: missing ${TARGET_PATH} and unable to locate ${DIST_PATH}." >&2
+      log_warn "Missing ${TARGET_PATH} and unable to locate ${DIST_PATH}."
     fi
+  else
+    log_debug "${TARGET_PATH} already exists; leaving in place"
   fi
 done
 
 WRAPPER_PATH="${INSTALL_PREFIX}/stationchat"
+log_info "Writing launcher script to ${WRAPPER_PATH}"
 cat <<'WRAP' >"${WRAPPER_PATH}"
 #!/usr/bin/env bash
 set -euo pipefail
+
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN="${DIR}/bin/stationchat"
+
+if [[ -t 1 ]]; then
+  C_INFO="\033[1;34m"
+  C_ERROR="\033[1;31m"
+  C_RESET="\033[0m"
+else
+  C_INFO=""
+  C_ERROR=""
+  C_RESET=""
+fi
+
+if [[ ! -x "${BIN}" ]]; then
+  printf '%s==> ERROR:%s Expected executable %s but it was not found. Did installation finish?\n' "${C_ERROR}" "${C_RESET}" "${BIN}" >&2
+  exit 1
+fi
+
+printf '%s==>%s Launching stationchat (%s)\n' "${C_INFO}" "${C_RESET}" "${BIN}"
 cd "${DIR}"
-exec "./bin/stationchat" "$@"
+exec "${BIN}" "$@"
 WRAP
 chmod +x "${WRAPPER_PATH}"
 
 RUN_LOCATION="${INSTALL_PREFIX}"
 if [[ -n "${RUN_LINK}" ]]; then
   if [[ -e "${RUN_LINK}" && ! -L "${RUN_LINK}" ]]; then
-    echo "Warning: ${RUN_LINK} exists and is not a symlink; skipping creation of chat run link." >&2
+    log_warn "${RUN_LINK} exists and is not a symlink; skipping creation of chat run link."
   else
     if ln -sfn "${INSTALL_PREFIX}" "${RUN_LINK}"; then
       RUN_LOCATION="${RUN_LINK}"
-      echo "Linked ${RUN_LINK} -> ${INSTALL_PREFIX}"
+      log_info "Linked ${RUN_LINK} -> ${INSTALL_PREFIX}"
     else
-      echo "Warning: unable to create ${RUN_LINK} -> ${INSTALL_PREFIX}. Create the link manually if desired." >&2
+      log_warn "Unable to create ${RUN_LINK} -> ${INSTALL_PREFIX}. Create the link manually if desired."
     fi
   fi
+else
+  log_debug "Run link disabled; skipping symlink creation"
 fi
 
-echo "Launcher installed to ${WRAPPER_PATH}"  
-echo "Start the chat server with:"  
-echo "  cd ${RUN_LOCATION}"  
+log_info "Launcher installed to ${WRAPPER_PATH}"
+log_info "Start the chat server with:"
+echo "  cd ${RUN_LOCATION}"
 echo "  ./stationchat"


### PR DESCRIPTION
## Summary
- update the generated stationchat launcher to emit a coloured status line before execing the binary
- add a guard that reports a clear error if the stationchat binary is missing when the launcher is run

## Testing
- bash -n extras/bootstrap_build.sh
- bash -n extras/finalize_chat_install.sh

------
https://chatgpt.com/codex/tasks/task_e_68fbc016626c832cb4e44b993bafe174