### PR TITLE
Normalize ChatRequestType byte order and validate incoming packet size

### DIFF
--- a/src/stationchat/ChatEnums.hpp
+++ b/src/stationchat/ChatEnums.hpp
@@ -249,4 +249,33 @@ struct ChatResultException {
         , message{text} {}
 };
 
+constexpr uint16_t ByteSwap16(uint16_t value) {
+    return static_cast<uint16_t>((value >> 8) | (value << 8));
+}
+
+constexpr bool IsKnownChatRequestTypeCode(uint16_t code) {
+    return code <= static_cast<uint16_t>(ChatRequestType::FILTERMESSAGE_EX)
+        || code == static_cast<uint16_t>(ChatRequestType::REGISTRAR_GETCHATSERVER);
+}
+
+inline bool TryNormalizeChatRequestType(
+    ChatRequestType requestType, ChatRequestType& normalizedType, bool& byteswapped) {
+    const auto requestCode = static_cast<uint16_t>(requestType);
+    if (IsKnownChatRequestTypeCode(requestCode)) {
+        normalizedType = requestType;
+        byteswapped = false;
+        return true;
+    }
+
+    const auto swappedCode = ByteSwap16(requestCode);
+    if (IsKnownChatRequestTypeCode(swappedCode)) {
+        normalizedType = static_cast<ChatRequestType>(swappedCode);
+        byteswapped = true;
+        return true;
+    }
+
+    byteswapped = false;
+    return false;
+}
+
 const char* ToString(ChatResultCode code);


### PR DESCRIPTION
### Motivation
- Ensure gateway and registrar clients robustly handle incoming request type values that may be in the wrong byte order and avoid processing malformed short packets.

### Description
- Add `ByteSwap16`, `IsKnownChatRequestTypeCode`, and `TryNormalizeChatRequestType` helpers in `ChatEnums.hpp` to detect and normalize possibly byte-swapped `ChatRequestType` values.
- Validate the available payload size before reading a `ChatRequestType` and drop/log packets that are too short in `GatewayClient::OnIncoming` and `RegistrarClient::OnIncoming`.
- Normalize the request type, log when a byte-swap was required, dispatch on the normalized type, and return early for unknown or invalid types.
- Update registrar handling to use the normalized request type and improve error logging for invalid registrar messages.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a095d1794c832c8971f16564a19fb4)