### PR TITLE
Add stream byte-swap serialization and propagate to clients

### DIFF
--- a/src/stationapi/NodeClient.hpp
+++ b/src/stationapi/NodeClient.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "UdpLibrary.hpp"
+#include "Serialization.hpp"
 
 #include <sstream>
 
@@ -15,12 +16,16 @@ public:
     void Send(const T& message) {
         ostream_.clear();
         ostream_.str("");
+        SetSerializationByteSwap(ostream_, connectionByteSwap_);
         write(ostream_, message);
         auto data = ostream_.str();
         Send(data.c_str(), data.length());
     }
 
     UdpConnection* GetConnection() { return connection_; }
+
+protected:
+    void SetConnectionByteSwap(bool enabled) { connectionByteSwap_ = enabled; }
 
 private:
     void Send(const char* data, uint32_t length);
@@ -32,4 +37,5 @@ private:
     std::ostringstream ostream_;
     std::istringstream istream_;
     UdpConnection* connection_;
+    bool connectionByteSwap_ = false;
 };

--- a/src/stationchat/GatewayClient.cpp
+++ b/src/stationchat/GatewayClient.cpp
@@ -7,6 +7,7 @@
 #include "GatewayNode.hpp"
 #include "Message.hpp"
 #include "PersistentMessageService.hpp"
+#include "Serialization.hpp"
 #include "MariaDB.hpp"
 #include "StationChatConfig.hpp"
 #include "UdpLibrary.hpp"
@@ -76,6 +77,9 @@ void GatewayClient::OnIncoming(std::istringstream& istream) {
                      << static_cast<uint16_t>(request_type) << " -> "
                      << static_cast<uint16_t>(normalized_request_type);
     }
+
+    SetSerializationByteSwap(istream, was_byteswapped);
+    SetConnectionByteSwap(was_byteswapped);
 
     switch (normalized_request_type) {
     case ChatRequestType::LOGINAVATAR:

--- a/src/stationchat/RegistrarClient.cpp
+++ b/src/stationchat/RegistrarClient.cpp
@@ -41,6 +41,9 @@ void RegistrarClient::OnIncoming(std::istringstream& istream) {
                      << static_cast<uint16_t>(normalized_request_type);
     }
 
+    SetSerializationByteSwap(istream, was_byteswapped);
+    SetConnectionByteSwap(was_byteswapped);
+
     switch (normalized_request_type) {
     case ChatRequestType::REGISTRAR_GETCHATSERVER: {
         auto request = ::read<ReqRegistrarGetChatServer>(istream);


### PR DESCRIPTION
### Motivation
- Add explicit per-stream byte-swap control so messages from byte-swapped peers can be correctly read and written.
- Propagate byte-swap state from incoming packets to connection/response serialization so replies use the same endianness.

### Description
- Introduce `Serialization.hpp` with `SetSerializationByteSwap`, `GetSerializationByteSwap`, `SerializationByteSwapFlagIndex`, and `ByteSwapIntegral`, and update `read`/`write` to honor the per-stream byte-swap flag for integral and enum types.
- Update `std::u16string` serialization to use the generic `read`/`write` helpers for its 16-bit elements.
- Extend `NodeClient` to set the stream byte-swap flag on outgoing streams via `SetSerializationByteSwap` and track connection byte-swap state with `SetConnectionByteSwap` and a `connectionByteSwap_` member.
- Update `GatewayClient` and `RegistrarClient` to set the incoming `istream` byte-swap flag and the connection byte-swap based on request-type normalization results.

### Testing
- Built the project (`make`) to validate compilation with the new header and changes, and the build succeeded.
- Ran the existing automated test suite (`ctest`), and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a09c0e54e8832cb3317c4bc43b408b)