### PR TITLE
Fix missing StationChatConfig API version symbols

### DIFF
--- a/src/stationchat/CMakeLists.txt
+++ b/src/stationchat/CMakeLists.txt
@@ -62,6 +62,7 @@ add_executable(
   RegistrarNode.hpp
   StationChatApp.cpp
   StationChatApp.hpp
+  StationChatConfig.cpp
   StationChatConfig.hpp)
   
 # cmake-format: off

--- a/src/stationchat/StationChatConfig.cpp
+++ b/src/stationchat/StationChatConfig.cpp
@@ -1,0 +1,5 @@
+#include "StationChatConfig.hpp"
+
+constexpr uint32_t StationChatConfig::kLegacyApiVersion;
+constexpr uint32_t StationChatConfig::kEnhancedApiVersion;
+constexpr uint32_t StationChatConfig::kCapabilityMaskForV3;


### PR DESCRIPTION
### Motivation
- Resolve undefined reference linker errors for `StationChatConfig::kLegacyApiVersion`, `kEnhancedApiVersion`, and `kCapabilityMaskForV3` that occur when building without in-class C++17 inline definitions. 
- Ensure the `stationchat` executable links the API/version symbols from a proper translation unit.

### Description
- Add `src/stationchat/StationChatConfig.cpp` which provides out-of-class definitions for `StationChatConfig` static `constexpr` members. 
- Update `src/stationchat/CMakeLists.txt` to include `StationChatConfig.cpp` in the `stationchat` target so the symbols are compiled and linked.

### Testing
- Successfully compiled the new translation unit with `g++ -std=c++14 -Isrc/stationchat -c src/stationchat/StationChatConfig.cpp -o /tmp/StationChatConfig.o` (succeeded). 
- Attempted a full configure/build with `cmake -S . -B build && cmake --build build --target stationchat -j4`, but configuration failed due to missing Boost `program_options` in the environment (failed). 
- Attempted `ant compile_chat` in this environment but `ant` is not installed so that target could not be run here (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0b17baf2c832c9d0a9de7ba2f22be)