### PR TITLE
Fix serialization build errors on C++14

### DIFF
--- a/src/stationapi/Serialization.hpp
+++ b/src/stationapi/Serialization.hpp
@@ -46,18 +46,15 @@ bool GetSerializationByteSwap(StreamT& stream) {
 
 template <typename T>
 constexpr T ByteSwapIntegral(T value) {
-    if constexpr (sizeof(T) == 1) {
-        return value;
-    } else {
-        using UnsignedT = typename std::make_unsigned<T>::type;
-        auto input = static_cast<UnsignedT>(value);
-        UnsignedT output = 0;
-        for (size_t i = 0; i < sizeof(T); ++i) {
-            output = static_cast<UnsignedT>((output << 8) | (input & 0xFFu));
-            input >>= 8;
-        }
-        return static_cast<T>(output);
+    using UnsignedT = typename std::make_unsigned<T>::type;
+    auto input = static_cast<UnsignedT>(value);
+    UnsignedT output = 0;
+    for (size_t i = 0; i < sizeof(T); ++i) {
+        output = static_cast<UnsignedT>((output << 8) | (input & 0xFFu));
+        input >>= 8;
     }
+
+    return static_cast<T>(output);
 }
 
 // integral types
@@ -147,7 +144,7 @@ void read(StreamT& istream, std::string& value) {
         return;
     }
 
-    istream.read(value.data(), length);
+    istream.read(&value[0], length);
 }
 
 template <typename StreamT>


### PR DESCRIPTION
### Motivation
- Fix compilation failures and warnings when building with pre-C++17 toolchains by removing C++17-only constructs and resolving a constness error in string deserialization.

### Description
- Replace use of `if constexpr` in `ByteSwapIntegral` with a C++14-compatible implementation that performs the byte-swap for integral types.
- Change `istream.read(value.data(), length)` to `istream.read(&value[0], length)` in `read(StreamT&, std::string&)` to provide a mutable buffer pointer and avoid `const char*` to `char*` conversion errors.
- All edits were made in `src/stationapi/Serialization.hpp`.

### Testing
- Attempted to configure and build with `cmake -S . -B build && cmake --build build -j4`, but configuration failed due to a missing Boost `program_options` include, so a full build and automated tests could not be completed (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0b26cc090832c90488fc05e8ee4c8)