### PR TITLE
Fix ChatEnums include path in SetApiVersion header

### DIFF
--- a/src/stationchat/protocol/SetApiVersion.hpp
+++ b/src/stationchat/protocol/SetApiVersion.hpp
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include "ChatEnums.hpp"
+#include "stationchat/ChatEnums.hpp"
 
 class ChatAvatarService;
 class ChatRoomService;


### PR DESCRIPTION
### Motivation
- Fix a compilation error where `tests/stationapi/ApiVersionNegotiation_Tests.cpp` could not find `ChatEnums.hpp` when pulling in `src/stationchat/protocol/SetApiVersion.hpp` via the `stationchat/protocol/...` path.

### Description
- Update `src/stationchat/protocol/SetApiVersion.hpp` to replace `#include "ChatEnums.hpp"` with `#include "stationchat/ChatEnums.hpp"` so the header resolves correctly from project include paths.

### Testing
- Attempted an automated configure/build with `cmake -S . -B build` and `cmake --build build -j4`, but configure failed due to missing Boost `program_options`, so a full build/test run could not complete; the include change was applied successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0b35cf020832c89bc9ea832e22be1)