### PR TITLE
Fix include path in SetApiVersion.hpp to resolve missing ChatEnums.hpp error

### DIFF
--- a/src/stationchat/protocol/SetApiVersion.hpp
+++ b/src/stationchat/protocol/SetApiVersion.hpp
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include "stationchat/ChatEnums.hpp"
+#include "ChatEnums.hpp"
 
 class ChatAvatarService;
 class ChatRoomService;


### PR DESCRIPTION
### Motivation
- The build failed with a missing-header error because `src/stationchat/protocol/SetApiVersion.hpp` included `stationchat/ChatEnums.hpp` while other protocol headers use `"ChatEnums.hpp"`, so the include path needed to be normalized to match the rest of the codebase.

### Description
- Updated the include in `src/stationchat/protocol/SetApiVersion.hpp` from `#include "stationchat/ChatEnums.hpp"` to `#include "ChatEnums.hpp"` and committed the change.

### Testing
- Ran the project configuration and build attempt with `cmake -S . -B build && cmake --build build -j2`, which could not complete because CMake failed to find Boost `program_options` in this environment, so a full build could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0b3ef9264832c91fc458c7bc92c23)