### PR TITLE
Fix stationapi tests include path for stationchat protocol headers

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 include_directories(${PROJECT_SOURCE_DIR}/externals/catch
-    ${PROJECT_SOURCE_DIR}/src)
+    ${PROJECT_SOURCE_DIR}/src
+    ${PROJECT_SOURCE_DIR}/src/stationchat)
 
 add_executable(stationapi_tests
     main.cpp


### PR DESCRIPTION
### Motivation
- Tests failed to compile due to protocol headers in `src/stationchat/protocol` including `ChatEnums.hpp` which was not found because the tests did not add `src/stationchat` to their include paths.

### Description
- Add ` ${PROJECT_SOURCE_DIR}/src/stationchat` to the `include_directories` in `tests/CMakeLists.txt` so headers like `ChatEnums.hpp` resolve when building `stationapi_tests`.

### Testing
- Ran configuration and build attempt with `cmake -S . -B build && cmake --build build`, but CMake configuration failed in this environment due to missing Boost (`program_options` / `Boost_INCLUDE_DIR`), so full compilation and test execution could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0b4a67014832ca523a317704345bd)