### PR TITLE
Fix undefined references for StationChatConfig API version constants

### DIFF
--- a/src/stationchat/StationChatConfig.cpp
+++ b/src/stationchat/StationChatConfig.cpp
@@ -1,5 +1,1 @@
 #include "StationChatConfig.hpp"
-
-constexpr uint32_t StationChatConfig::kLegacyApiVersion;
-constexpr uint32_t StationChatConfig::kEnhancedApiVersion;
-constexpr uint32_t StationChatConfig::kCapabilityMaskForV3;

--- a/src/stationchat/StationChatConfig.hpp
+++ b/src/stationchat/StationChatConfig.hpp
@@ -66,9 +66,11 @@ struct StationChatConfig {
         return stream.str();
     }
 
-    static constexpr uint32_t kLegacyApiVersion = 2;
-    static constexpr uint32_t kEnhancedApiVersion = 3;
-    static constexpr uint32_t kCapabilityMaskForV3 = 0x1;
+    enum : uint32_t {
+        kLegacyApiVersion = 2,
+        kEnhancedApiVersion = 3,
+        kCapabilityMaskForV3 = 0x1
+    };
 
     uint32_t apiMinVersion{kLegacyApiVersion};
     uint32_t apiMaxVersion{kEnhancedApiVersion};


### PR DESCRIPTION
### Motivation

- Tests that link only against `stationapi` were failing to link due to undefined references to `StationChatConfig` API version constants that were previously defined out-of-line in a separate translation unit.
- Replace the external-storage constants with compile-time integral constants that do not require an out-of-line definition so consumers can ODR-use them without pulling in `stationchat` object files.

### Description

- Replaced `static constexpr` API version members with an anonymous `enum : uint32_t` containing `kLegacyApiVersion`, `kEnhancedApiVersion`, and `kCapabilityMaskForV3` in `src/stationchat/StationChatConfig.hpp`.
- Removed the out-of-class `constexpr` definitions from `src/stationchat/StationChatConfig.cpp`, leaving only the header include.
- Changes are limited to `src/stationchat/StationChatConfig.hpp` and `src/stationchat/StationChatConfig.cpp` and preserve existing APIs and usage sites.

### Testing

- The original linker failure was observed when linking `tests/stationapi_tests` and showed undefined references to `StationChatConfig::kLegacyApiVersion`, `kEnhancedApiVersion`, and `kCapabilityMaskForV3` during the build.
- An attempted `cmake -S . -B build && cmake --build build -j4` after the fix could not complete the full build because CMake configure failed in this environment due to missing Boost development components (`Boost_INCLUDE_DIR` / `program_options`), so no unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0b53a7918832c8a279a0f3691914e)